### PR TITLE
Better filters validations

### DIFF
--- a/test/kino_explorer/data_transform_cell_test.exs
+++ b/test/kino_explorer/data_transform_cell_test.exs
@@ -104,6 +104,20 @@ defmodule KinoExplorer.DataTransformCellTest do
              """
     end
 
+    test "do not generate code for invalid filters" do
+      attrs =
+        build_attrs(%{
+          "filters" => [
+            %{"column" => "name", "filter" => "equal", "type" => "string", "value" => "Ana"},
+            %{"column" => "id", "filter" => "less", "type" => "integer", "value" => "Ana"}
+          ]
+        })
+
+      assert DataTransformCell.to_source(attrs) == """
+             people |> Explorer.DataFrame.filter(name == "Ana")\
+             """
+    end
+
     test "source for a data frame with columns with spaces" do
       root = %{"data_frame" => "df", "assign_to" => "new_df"}
 


### PR DESCRIPTION
This will avoid crashes when attempting invalid casts. It will also avoid generating code for invalid filters. When we get the new design, I'll implement error messages in the frontend for wrong filter types.