### PR TITLE
Overt operations

### DIFF
--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -82,6 +82,11 @@ input[type="number"] {
   font-weight: 500;
 }
 
+.validation-message {
+  margin-left: 60px;
+  color: var(--red--300);
+}
+
 .required {
   border: 1px solid var(--red--300);
 }

--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -20,6 +20,7 @@
   --yellow-600: #ffa83f;
 
   --red--300: #F1A3A6;
+  --red--500: #E2474D;
 }
 
 p,
@@ -82,9 +83,15 @@ input[type="number"] {
   font-weight: 500;
 }
 
+.validation-wrapper {
+  width: 24px;
+  position: relative;
+  left: 85%;
+  bottom: 25%;
+}
+
 .validation-message {
-  margin-left: 60px;
-  color: var(--red--300);
+  text-transform: lowercase;
 }
 
 .required {
@@ -383,4 +390,73 @@ select option {
 
 .operations {
   padding: 12px 0;
+}
+
+.tooltip {
+  position: relative;
+  bottom: 40%;
+  display: flex;
+  --distance: 4px;
+  --arrow-size: 5px;
+  --show-delay: 0.5s;
+}
+
+.tooltip:before {
+  position: absolute;
+  content: attr(data-tooltip);
+  white-space: pre;
+  text-align: center;
+  display: block;
+  z-index: 100;
+  background-color: #1c273c;
+  color: #f0f5f9;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 4px;
+  padding: 3px 12px;
+  visibility: hidden;
+  transition-property: visibility;
+  transition-duration: 0s;
+  transition-delay: 0s;
+}
+
+/* Tooltip arrow */
+.tooltip:after {
+  content: "";
+  position: absolute;
+  display: block;
+  z-index: 100;
+  /* For the arrow we use the triangle trick: https://css-tricks.com/snippets/css/css-triangle/ */
+  border-width: var(--arrow-size);
+  border-style: solid;
+  border-color: #1c273c;
+  visibility: hidden;
+  transition-property: visibility;
+  transition-duration: 0s;
+  transition-delay: 0s;
+}
+
+.tooltip:hover:before {
+  visibility: visible;
+  transition-delay: var(--show-delay);
+}
+
+.tooltip:hover:after {
+  visibility: visible;
+  transition-delay: var(--show-delay);
+}
+
+.tooltip.right:before {
+  top: 50%;
+  left: 100%;
+  transform: translate(calc(var(--arrow-size) - 1px + var(--distance)), -50%);
+}
+
+.tooltip.right:after {
+  top: 50%;
+  left: 100%;
+  transform: translate(var(--distance), -50%);
+  border-left: none;
+  border-top-color: transparent;
+  border-bottom-color: transparent;
 }

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -288,7 +288,7 @@ export function init(ctx, payload) {
                   <div class="row">
                     <BaseSelect
                       name="column"
-                      operation="filters"
+                      operation_type="filters"
                       label="Filter By"
                       v-model="filter.column"
                       :options="dataFrameColumns"
@@ -297,7 +297,7 @@ export function init(ctx, payload) {
                     />
                     <BaseSelect
                       name="filter"
-                      operation="filters"
+                      operation_type="filters"
                       label="Operation"
                       v-model="filter.filter"
                       :options="filterOptionsByType(filter.column)"
@@ -308,7 +308,7 @@ export function init(ctx, payload) {
                     <BaseSelect
                       v-if="filter.type === 'boolean'"
                       name="value"
-                      operation="filters"
+                      operation_type="filters"
                       label="Filter value"
                       v-model="filter.value"
                       :options="['true', 'false']"
@@ -319,7 +319,7 @@ export function init(ctx, payload) {
                     <BaseInput
                       v-else
                       name="value"
-                      operation="filters"
+                      operation_type="filters"
                       label="Value"
                       :index="index"
                       placeholder="Filter value"
@@ -346,7 +346,7 @@ export function init(ctx, payload) {
                   <div class="row">
                     <BaseSelect
                       name="sort_by"
-                      operation="sorting"
+                      operation_type="sorting"
                       label="Sort By"
                       v-model="sort.sort_by"
                       :options="dataFrameColumns"
@@ -355,7 +355,7 @@ export function init(ctx, payload) {
                     />
                     <BaseSelect
                       name="direction"
-                      operation="sorting"
+                      operation_type="sorting"
                       label="Direction"
                       v-model="sort.direction"
                       :options="orderOptions"
@@ -384,7 +384,7 @@ export function init(ctx, payload) {
                   <div class="row">
                     <BaseSelect
                       name="names_from"
-                      operation="pivot_wider"
+                      operation_type="pivot_wider"
                       label="Pivot names from"
                       v-model="pivot_wider.names_from"
                       :options="dataFrameColumns"
@@ -393,7 +393,7 @@ export function init(ctx, payload) {
                     />
                     <BaseSelect
                       name="values_from"
-                      operation="pivot_wider"
+                      operation_type="pivot_wider"
                       label="Pivot values from"
                       v-model="pivot_wider.values_from"
                       :options="dataFrameColumns"
@@ -472,22 +472,25 @@ export function init(ctx, payload) {
       handleFieldChange(event) {
         const field = event.target.name;
         const idx = event.target.getAttribute("index");
-        const operation = event.target.getAttribute("operation");
+        const operation_type = event.target.getAttribute("operation_type");
         const value = idx
-          ? this.operations[operation][idx][field]
+          ? this.operations[operation_type][idx][field]
           : this.rootFields[field];
         ctx.pushEvent("update_field", {
-          operation,
+          operation_type,
           field,
           value,
           idx: idx && parseInt(idx),
         });
       },
-      addOperation(operation) {
-        ctx.pushEvent("add_operation", { operation });
+      addOperation(operation_type) {
+        ctx.pushEvent("add_operation", { operation_type });
       },
-      removeOperation(operation, idx) {
-        ctx.pushEvent("remove_operation", { operation, idx: parseInt(idx) });
+      removeOperation(operation_type, idx) {
+        ctx.pushEvent("remove_operation", {
+          operation_type,
+          idx: parseInt(idx),
+        });
       },
       hasOperations(operation) {
         return this.operations[operation].length > 0;
@@ -506,8 +509,8 @@ export function init(ctx, payload) {
     setRootValues(fields);
   });
 
-  ctx.handleEvent("update_operation", ({ operation, idx, fields }) => {
-    setOperationValues(operation, idx, fields);
+  ctx.handleEvent("update_operation", ({ operation_type, idx, fields }) => {
+    setOperationValues(operation_type, idx, fields);
   });
 
   ctx.handleEvent("update_data_frame", ({ fields }) => {
@@ -533,15 +536,15 @@ export function init(ctx, payload) {
     }
   }
 
-  function setOperationValues(operation, idx, fields) {
+  function setOperationValues(operation_type, idx, fields) {
     for (const field in fields) {
-      app.operations[operation][idx][field] = fields[field];
+      app.operations[operation_type][idx][field] = fields[field];
     }
   }
 
   function setOperations(operations) {
-    for (const operation in operations) {
-      app.operations[operation] = operations[operation];
+    for (const operation_type in operations) {
+      app.operations[operation_type] = operations[operation_type];
     }
   }
 }

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -84,6 +84,10 @@ export function init(ctx, payload) {
         type: String,
         default: "",
       },
+      message: {
+        type: String,
+        default: "",
+      },
       inputClass: {
         type: String,
         default: "input",
@@ -105,7 +109,7 @@ export function init(ctx, payload) {
     template: `
     <div v-bind:class="[inline ? 'inline-field' : 'field', grow ? 'grow' : '']">
       <label v-bind:class="inline ? 'inline-input-label' : 'input-label'">
-        {{ label }}
+        {{ label }} <span class="validation-message">{{ message }}</span>
       </label>
       <input
         :value="modelValue"
@@ -321,6 +325,7 @@ export function init(ctx, payload) {
                       name="value"
                       operation_type="filters"
                       label="Value"
+                      :message="filter.message"
                       :index="index"
                       placeholder="Filter value"
                       v-model="filter.value"

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -331,6 +331,42 @@ export function init(ctx, payload) {
                 </template>
               </Accordion>
             </div>
+            <div class="operations" v-if="hasOperations('sorting')">
+              <Accordion
+                class="operations-wrapper"
+                v-for="(sort, index) in operations.sorting"
+                @remove-operation="removeOperation('sorting', index)"
+                :hasOperations="hasOperations('sorting')"
+              >
+                <template v-slot:title>
+                  <span v-if="sort.sort_by">{{ sort.sort_by }}: {{ sort.order }}</span>
+                  <span v-else>Empty sorting</span>
+                </template>
+                <template v-slot:content>
+                  <div class="row">
+                    <BaseSelect
+                      name="sort_by"
+                      operation="sorting"
+                      label="Sort By"
+                      v-model="sort.sort_by"
+                      :options="dataFrameColumns"
+                      :index="index"
+                      :disabled="noDataFrame"
+                    />
+                    <BaseSelect
+                      name="direction"
+                      operation="sorting"
+                      label="Direction"
+                      v-model="sort.direction"
+                      :options="orderOptions"
+                      :required
+                      :index="index"
+                      :disabled="noDataFrame"
+                    />
+                  </div>
+                </template>
+              </Accordion>
+            </div>
             <div class="operations" v-if="hasOperations('pivot_wider')">
               <Accordion
                 class="operations-wrapper"
@@ -361,42 +397,6 @@ export function init(ctx, payload) {
                       label="Pivot values from"
                       v-model="pivot_wider.values_from"
                       :options="dataFrameColumns"
-                      :index="index"
-                      :disabled="noDataFrame"
-                    />
-                  </div>
-                </template>
-              </Accordion>
-            </div>
-            <div class="operations" v-if="hasOperations('sorting')">
-              <Accordion
-                class="operations-wrapper"
-                v-for="(sort, index) in operations.sorting"
-                @remove-operation="removeOperation('sorting', index)"
-                :hasOperations="hasOperations('sorting')"
-              >
-                <template v-slot:title>
-                  <span v-if="sort.sort_by">{{ sort.sort_by }}: {{ sort.order }}</span>
-                  <span v-else>Empty sorting</span>
-                </template>
-                <template v-slot:content>
-                  <div class="row">
-                    <BaseSelect
-                      name="sort_by"
-                      operation="sorting"
-                      label="Sort By"
-                      v-model="sort.sort_by"
-                      :options="dataFrameColumns"
-                      :index="index"
-                      :disabled="noDataFrame"
-                    />
-                    <BaseSelect
-                      name="direction"
-                      operation="sorting"
-                      label="Direction"
-                      v-model="sort.direction"
-                      :options="orderOptions"
-                      :required
                       :index="index"
                       :disabled="noDataFrame"
                     />

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -401,7 +401,7 @@ export function init(ctx, payload) {
                       operation_type="pivot_wider"
                       label="Pivot names from"
                       v-model="pivot_wider.names_from"
-                      :options="dataFrameColumns"
+                      :options="dataFrameColumnsByType('string')"
                       :index="index"
                       :disabled="noDataFrame"
                     />
@@ -410,7 +410,7 @@ export function init(ctx, payload) {
                       operation_type="pivot_wider"
                       label="Pivot values from"
                       v-model="pivot_wider.values_from"
-                      :options="dataFrameColumns"
+                      :options="dataFrameColumnsByType('integer')"
                       :index="index"
                       :disabled="!pivot_wider.names_from"
                     />
@@ -515,6 +515,15 @@ export function init(ctx, payload) {
       },
       columnType(column) {
         return this.dataFrameInfo?.columns[column];
+      },
+      dataFrameColumnsByType(supportedType) {
+        const dataFrameColumns = this.dataFrameInfo
+          ? this.dataFrameInfo.columns
+          : {};
+        const supportedColumns = Object.entries(dataFrameColumns)
+          .filter(([col, type]) => type === supportedType)
+          .map(([col, type]) => col);
+        return supportedColumns;
       },
     },
   }).mount(ctx.root);

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -315,7 +315,7 @@ export function init(ctx, payload) {
                       v-model="filter.filter"
                       :options="filterOptionsByType(filter.column)"
                       :required
-                      :disabled="noDataFrame"
+                      :disabled="!filter.column"
                       :index="index"
                     />
                     <BaseSelect
@@ -326,7 +326,7 @@ export function init(ctx, payload) {
                       v-model="filter.value"
                       :options="['true', 'false']"
                       :required
-                      :disabled="noDataFrame"
+                      :disabled="!filter.column"
                       :index="index"
                     />
                     <BaseInput
@@ -338,7 +338,7 @@ export function init(ctx, payload) {
                       :index="index"
                       placeholder="Filter value"
                       v-model="filter.value"
-                      :disabled="noDataFrame"
+                      :disabled="!filter.column"
                       :required
                     />
                   </div>
@@ -375,7 +375,7 @@ export function init(ctx, payload) {
                       :options="orderOptions"
                       :required
                       :index="index"
-                      :disabled="noDataFrame"
+                      :disabled="!sort.sort_by"
                     />
                   </div>
                 </template>
@@ -412,7 +412,7 @@ export function init(ctx, payload) {
                       v-model="pivot_wider.values_from"
                       :options="dataFrameColumns"
                       :index="index"
-                      :disabled="noDataFrame"
+                      :disabled="!pivot_wider.names_from"
                     />
                   </div>
                 </template>

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -109,7 +109,7 @@ export function init(ctx, payload) {
     template: `
     <div v-bind:class="[inline ? 'inline-field' : 'field', grow ? 'grow' : '']">
       <label v-bind:class="inline ? 'inline-input-label' : 'input-label'">
-        {{ label }} <span class="validation-message">{{ message }}</span>
+        {{ label }}
       </label>
       <input
         :value="modelValue"
@@ -117,6 +117,15 @@ export function init(ctx, payload) {
         v-bind="$attrs"
         v-bind:class="inputClass"
       >
+      <div class="validation-wrapper">
+      <span class="tooltip right validation-message" :data-tooltip="message" v-if="message">
+        <svg class="validation-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+          <path fill="none" d="M0 0h24v24H0z"/>
+          <path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm-1-7v2h2v-2h-2zm0-8v6h2V7h-2z"
+          fill="#E2474D"/>
+        </svg>
+      </span>
+      </div>
     </div>
     `,
   };

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -453,7 +453,7 @@ export function init(ctx, payload) {
             "greater",
           ],
           categorical: ["equal", "contains", "not equal"],
-          boolean: ["true", "false"],
+          boolean: ["equal", "not equal"],
         },
         columnTypes: {
           float: "numeric",

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -15,9 +15,7 @@ defmodule KinoExplorer.DataTransformCell do
     "not equal" => "!=",
     "greater equal" => ">=",
     "greater" => ">",
-    "contains" => "contains",
-    "true" => "true",
-    "false" => "false"
+    "contains" => "contains"
   }
 
   @impl true

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -95,11 +95,8 @@ defmodule KinoExplorer.DataTransformCell do
     {:noreply, ctx}
   end
 
-  def handle_event(
-        "update_field",
-        %{"operation_type" => nil, "field" => field, "value" => value},
-        ctx
-      ) do
+  def handle_event("update_field", %{"operation_type" => nil} = fields, ctx) do
+    {field, value} = {fields["field"], fields["value"]}
     parsed_value = parse_value(field, value)
     ctx = update(ctx, :root_fields, &Map.put(&1, field, parsed_value))
     broadcast_event(ctx, "update_root", %{"fields" => %{field => parsed_value}})
@@ -184,7 +181,13 @@ defmodule KinoExplorer.DataTransformCell do
 
     case field do
       "column" ->
-        %{"filter" => "equal", "column" => column, "value" => nil, "type" => type}
+        %{
+          "filter" => "equal",
+          "column" => column,
+          "value" => nil,
+          "type" => type,
+          "message" => message
+        }
 
       "value" ->
         %{
@@ -196,7 +199,13 @@ defmodule KinoExplorer.DataTransformCell do
         }
 
       "filter" ->
-        %{"filter" => value, "column" => column, "value" => nil, "type" => type}
+        %{
+          "filter" => value,
+          "column" => column,
+          "value" => nil,
+          "type" => type,
+          "message" => message
+        }
     end
   end
 

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -388,7 +388,7 @@ defmodule KinoExplorer.DataTransformCell do
 
     case cast_filter_value(type, value) do
       {:ok, _} -> nil
-      _ -> "invalid value"
+      _ -> "not #{type}"
     end
   end
 

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -388,7 +388,7 @@ defmodule KinoExplorer.DataTransformCell do
 
     case cast_filter_value(type, value) do
       {:ok, _} -> nil
-      _ -> "not #{type}"
+      _ -> "invalid value for type #{type}"
     end
   end
 

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -247,7 +247,7 @@ defmodule KinoExplorer.DataTransformCell do
       }
     ]
 
-    nodes = filters ++ pivot ++ sorting
+    nodes = filters ++ sorting ++ pivot
     root = build_root(df)
     Enum.reduce(nodes, root, &apply_node/2) |> build_var(variable)
   end


### PR DESCRIPTION
- Differentiate operations and operation types
- Move `pivot_wider` to the end (we need this for now, as I don't update the DF columns after operations yet)
- Dynamically disable fields (to avoid hitting the server with "incomplete/invalid options")
- Validation messages (only for filter atm)
- Filter columns for `pivot_wider` (the select will now show only supported columns for names and values)
- Minor fixes and adjustments