### PR TITLE
Group by and summarization

### DIFF
--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -495,6 +495,10 @@ select option {
   background-color: var(--purple-600);
 }
 
+.card.group_by:before {
+  background-color: var(--magenta-600);
+}
+
 .card.pivot_wider:before {
   background-color: var(--orange-600);
 }
@@ -509,6 +513,10 @@ select option {
 
 .operations.sorting {
   border-left: solid 3px var(--purple-600);
+}
+
+.operations.group_by {
+  border-left: solid 3px var(--magenta-600);
 }
 
 .operations.pivot_wider {
@@ -534,6 +542,10 @@ select option {
 
 .card.sorting {
   background-color: var(--purple-100);
+}
+
+.card.group_by {
+  background-color: var(--magenta-100);
 }
 
 .card.pivot_wider {
@@ -683,6 +695,12 @@ select option {
   transform: translateX(100%);
 }
 
+.switch-button-checkbox.group_by:checked {
+  background: white;
+  border-color: var(--magenta-600);
+  transform: translateX(100%);
+}
+
 .switch-button-checkbox.pivot_wider:checked {
   background: white;
   border-color: var(--orange-600);
@@ -703,6 +721,10 @@ select option {
 
 .switch-button-checkbox.sorting:checked + .switch-button-bg {
   background-color: var(--purple-600);
+}
+
+.switch-button-checkbox.group_by:checked + .switch-button-bg {
+  background-color: var(--magenta-600);
 }
 
 .switch-button-checkbox.pivot_wider:checked + .switch-button-bg {
@@ -729,6 +751,11 @@ select option {
   border-color: var(--purple-100);
 }
 
+.switch-button-checkbox.group_by:disabled {
+  background: white;
+  border-color: var(--magenta-100);
+}
+
 .switch-button-checkbox.pivot_wider:disabled {
   background: white;
   border-color: var(--orange-100);
@@ -748,6 +775,10 @@ select option {
 
 .switch-button-checkbox.sorting:disabled + .switch-button-bg {
   background-color: var(--purple-200);
+}
+
+.switch-button-checkbox.group_by:disabled + .switch-button-bg {
+  background-color: var(--magenta-200);
 }
 
 .switch-button-checkbox.pivot_wider:disabled + .switch-button-bg {

--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -47,6 +47,10 @@
   --purple-100: #f4f2fd;
   --purple-200: #d2cbef;
   --purple-600: #957fef;
+
+  --marsala-100: #F0DFE4;
+  --marsala-200: #E1BFC8;
+  --marsala-600: #B45F76;
 }
 
 p,
@@ -499,6 +503,10 @@ select option {
   background-color: var(--magenta-600);
 }
 
+.card.summarise:before {
+  background-color: var(--marsala-600);
+}
+
 .card.pivot_wider:before {
   background-color: var(--orange-600);
 }
@@ -517,6 +525,10 @@ select option {
 
 .operations.group_by {
   border-left: solid 3px var(--magenta-600);
+}
+
+.operations.summarise {
+  border-left: solid 3px var(--marsala-600);
 }
 
 .operations.pivot_wider {
@@ -546,6 +558,10 @@ select option {
 
 .card.group_by {
   background-color: var(--magenta-100);
+}
+
+.card.summarise {
+  background-color: var(--marsala-100);
 }
 
 .card.pivot_wider {
@@ -701,6 +717,12 @@ select option {
   transform: translateX(100%);
 }
 
+.switch-button-checkbox.summarise:checked {
+  background: white;
+  border-color: var(--marsala-600);
+  transform: translateX(100%);
+}
+
 .switch-button-checkbox.pivot_wider:checked {
   background: white;
   border-color: var(--orange-600);
@@ -725,6 +747,10 @@ select option {
 
 .switch-button-checkbox.group_by:checked + .switch-button-bg {
   background-color: var(--magenta-600);
+}
+
+.switch-button-checkbox.summarise:checked + .switch-button-bg {
+  background-color: var(--marsala-600);
 }
 
 .switch-button-checkbox.pivot_wider:checked + .switch-button-bg {
@@ -756,6 +782,11 @@ select option {
   border-color: var(--magenta-100);
 }
 
+.switch-button-checkbox.summarise:disabled {
+  background: white;
+  border-color: var(--marsala-100);
+}
+
 .switch-button-checkbox.pivot_wider:disabled {
   background: white;
   border-color: var(--orange-100);
@@ -779,6 +810,10 @@ select option {
 
 .switch-button-checkbox.group_by:disabled + .switch-button-bg {
   background-color: var(--magenta-200);
+}
+
+.switch-button-checkbox.summarise:disabled + .switch-button-bg {
+  background-color: var(--marsala-200);
 }
 
 .switch-button-checkbox.pivot_wider:disabled + .switch-button-bg {

--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -28,7 +28,7 @@
   --red-300: #f1a3a6;
   --red-500: #e2474d;
 
-  --magenta-100: #faedfa;
+  --magenta-100: #fff1ff;
   --magenta-200: #fad4fa;
   --magenta-600: #c689c6;
 

--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -48,9 +48,9 @@
   --purple-200: #d2cbef;
   --purple-600: #957fef;
 
-  --marsala-100: #F0DFE4;
-  --marsala-200: #E1BFC8;
-  --marsala-600: #B45F76;
+  --beige-100: #FBF5F1;
+  --beige-200: #F8EBE4;
+  --beige-600: #EDCDBB;
 }
 
 p,
@@ -505,7 +505,7 @@ select option {
 }
 
 .card.summarise:before {
-  background-color: var(--marsala-600);
+  background-color: var(--beige-600);
 }
 
 .card.pivot_wider:before {
@@ -529,7 +529,7 @@ select option {
 }
 
 .operations.summarise {
-  border-left: solid 3px var(--marsala-600);
+  border-left: solid 3px var(--beige-600);
 }
 
 .operations.pivot_wider {
@@ -562,7 +562,7 @@ select option {
 }
 
 .card.summarise {
-  background-color: var(--marsala-100);
+  background-color: var(--beige-100);
 }
 
 .card.pivot_wider {
@@ -720,7 +720,7 @@ select option {
 
 .switch-button-checkbox.summarise:checked {
   background: white;
-  border-color: var(--marsala-600);
+  border-color: var(--beige-600);
   transform: translateX(100%);
 }
 
@@ -751,7 +751,7 @@ select option {
 }
 
 .switch-button-checkbox.summarise:checked + .switch-button-bg {
-  background-color: var(--marsala-600);
+  background-color: var(--beige-600);
 }
 
 .switch-button-checkbox.pivot_wider:checked + .switch-button-bg {
@@ -785,7 +785,7 @@ select option {
 
 .switch-button-checkbox.summarise:disabled {
   background: white;
-  border-color: var(--marsala-100);
+  border-color: var(--beige-100);
 }
 
 .switch-button-checkbox.pivot_wider:disabled {
@@ -814,7 +814,7 @@ select option {
 }
 
 .switch-button-checkbox.summarise:disabled + .switch-button-bg {
-  background-color: var(--marsala-200);
+  background-color: var(--beige-200);
 }
 
 .switch-button-checkbox.pivot_wider:disabled + .switch-button-bg {

--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -418,7 +418,8 @@ select option {
   cursor: move;
 }
 
-.card.pivot_wider:hover {
+.card.pivot_wider:hover,
+.card.summarise:hover {
   cursor: default;
 }
 

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -391,14 +391,17 @@ export async function init(ctx, payload) {
               <Container @drop="handleItemDrop" lock-axis="y" non-drag-area-selector=".field">
                 <Draggable
                   v-for="(operation, index) in operations"
-                  :drag-not-allowed="operation.operation_type === 'pivot_wider'"
+                  :drag-not-allowed="operation.operation_type === 'pivot_wider' || operation.operation_type === 'summarise'"
                 >
                   <div :class="['operations', operation.operation_type]">
                     <BaseCard
                       :class="operation.operation_type"
                       @remove-operation="removeOperation(operation.operation_type, index)"
                     >
-                      <template v-slot:move v-if="operation.operation_type !== 'pivot_wider'">
+                      <template
+                        v-slot:move
+                        v-if="operation.operation_type !== 'pivot_wider' && operation.operation_type !== 'summarise'"
+                      >
                         <svg class="button-svg drag-move" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
                           <defs>
                             <path fill="none" d="M0 0h24v24H0z"/>
@@ -619,11 +622,11 @@ export async function init(ctx, payload) {
               <BaseButton label="Sorting" @add-operation="addOperation('sorting')" :disabled="noDataFrame"/>
               <BaseButton label="Filter" @add-operation="addOperation('filters')" :disabled="noDataFrame"/>
               <BaseButton label="Fill Missing" @add-operation="addOperation('fill_missing')" :disabled="noDataFrame"/>
-              <BaseButton label="Group by" @add-operation="addOperation('group_by')" :disabled="noDataFrame"/>
+              <BaseButton label="Group by" @add-operation="addOperation('group_by')" :disabled="hasOperation('group_by')"/>
               <BaseButton
                 label="Summarise"
                 @add-operation="addOperation('summarise')"
-                :disabled="!hasOperation('group_by') || hasOperation('pivot_wider')"/>
+                :disabled="!hasValidGroups || hasOperation('pivot_wider')"/>
               <BaseButton
                 :disabled="hasOperation('pivot_wider') || hasOperation('summarise')"
                 label="Pivot Wider"
@@ -690,11 +693,19 @@ export async function init(ctx, payload) {
       noDataFrame() {
         return !this.rootFields.data_frame;
       },
+      hasValidGroups() {
+        const groups = this.operations.find(
+          (operation) => operation.operation_type === "group_by"
+        );
+        return groups ? groups.group_by.length > 0 : false;
+      },
     },
 
     methods: {
       hasOperation(operation_type) {
-        return this.operations.some((operation) => operation.operation_type === operation_type)
+        return this.operations.some(
+          (operation) => operation.operation_type === operation_type
+        );
       },
       handleFieldChange(event) {
         const field = event.target.name;
@@ -744,9 +755,12 @@ export async function init(ctx, payload) {
         return supportedColumns;
       },
       handleItemDrop({ removedIndex, addedIndex }) {
-        const maxAllowed = this.hasPivotWider
-          ? this.operations.length - 2
-          : this.operations.length - 1;
+        const offset = this.operations.filter(
+          (operation) =>
+            operation.operation_type === "pivot_wider" ||
+            operation.operation_type === "summarise"
+        ).length;
+        const maxAllowed = this.operations.length - offset - 1;
         addedIndex = Math.min(addedIndex, maxAllowed);
         if (removedIndex === addedIndex) return;
         ctx.pushEvent("move_operation", { removedIndex, addedIndex });

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -521,6 +521,19 @@ export async function init(ctx, payload) {
                             :disabled="!operation.sort_by"
                           />
                         </div>
+                        <div class="row" v-if="operation.operation_type === 'group_by'">
+                          <BaseMultiTagSelect
+                            @change.self="addInnerValue($event)"
+                            operation_type="group_by"
+                            label="Group by"
+                            v-model="operation.group_by"
+                            :options="dataFrameColumns"
+                            :index="index"
+                            field="group_by"
+                            :disabled="noDataFrame"
+                            @remove-inner-value="removeInnerValue(index, 'group_by', $event)"
+                          />
+                        </div>
                         <div class="row" v-if="operation.operation_type === 'pivot_wider'">
                           <BaseSelect
                             name="names_from"
@@ -584,6 +597,7 @@ export async function init(ctx, payload) {
               <BaseButton label="Sorting" @add-operation="addOperation('sorting')" :disabled="noDataFrame"/>
               <BaseButton label="Filter" @add-operation="addOperation('filters')" :disabled="noDataFrame"/>
               <BaseButton label="Fill Missing" @add-operation="addOperation('fill_missing')" :disabled="noDataFrame"/>
+              <BaseButton label="Group by" @add-operation="addOperation('group_by')" :disabled="noDataFrame"/>
               <BaseButton
                 :disabled="hasPivotWider"
                 label="Pivot Wider"

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -549,7 +549,7 @@ export async function init(ctx, payload) {
                             operation_type="summarise"
                             label="Columns"
                             v-model="operation.columns"
-                            :options="dataFrameColumns"
+                            :options="dataFrameColumnsByTypes(['integer', 'float', 'date', 'time'])"
                             :index="index"
                             field="columns"
                             :disabled="noDataFrame"
@@ -562,7 +562,7 @@ export async function init(ctx, payload) {
                             operation_type="pivot_wider"
                             label="Pivot names from"
                             v-model="operation.names_from"
-                            :options="dataFrameColumnsByType('string')"
+                            :options="dataFrameColumnsByTypes(['string'])"
                             :index="index"
                             :disabled="noDataFrame"
                           />
@@ -571,7 +571,7 @@ export async function init(ctx, payload) {
                             operation_type="pivot_wider"
                             label="Values from"
                             v-model="operation.values_from"
-                            :options="dataFrameColumnsByType('integer')"
+                            :options="dataFrameColumnsByTypes(['integer'])"
                             :index="index"
                             field="values_from"
                             :disabled="noDataFrame"
@@ -734,12 +734,12 @@ export async function init(ctx, payload) {
       columnType(column) {
         return this.dataFrameInfo?.columns[column];
       },
-      dataFrameColumnsByType(supportedType) {
+      dataFrameColumnsByTypes(supportedTypes) {
         const dataFrameColumns = this.dataFrameInfo
           ? this.dataFrameInfo.columns
           : {};
         const supportedColumns = Object.entries(dataFrameColumns)
-          .filter(([col, type]) => type === supportedType)
+          .filter(([col, type]) => supportedTypes.includes(type))
           .map(([col, type]) => col);
         return supportedColumns;
       },

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -538,25 +538,25 @@ export async function init(ctx, payload) {
                           />
                         </div>
                         <div class="row" v-if="operation.operation_type === 'summarise'">
-                          <BaseSelect
-                            name="query"
-                            operation_type="summarise"
-                            label="Summarise by"
-                            v-model="operation.query"
-                            :options="summariseOptions"
-                            :index="index"
-                            :disabled="noDataFrame"
-                          />
                           <BaseMultiTagSelect
                             @change.self="addInnerValue($event)"
                             operation_type="summarise"
-                            label="Columns"
+                            label="Summarise by"
                             v-model="operation.columns"
-                            :options="dataFrameColumnsByTypes(['integer', 'float', 'date', 'time'])"
+                            :options="dataFrameColumnsByTypes(['integer', 'float', 'date', 'time', 'datetime'])"
                             :index="index"
                             field="columns"
                             :disabled="noDataFrame"
                             @remove-inner-value="removeInnerValue(index, 'columns', $event)"
+                          />
+                          <BaseSelect
+                            name="query"
+                            operation_type="summarise"
+                            label="Using"
+                            v-model="operation.query"
+                            :options="summariseOptions"
+                            :index="index"
+                            :disabled="noDataFrame"
                           />
                         </div>
                         <div class="row" v-if="operation.operation_type === 'pivot_wider'">
@@ -619,18 +619,19 @@ export async function init(ctx, payload) {
               </Container>
             </div>
             <div class="add-operation">
-              <BaseButton label="Sorting" @add-operation="addOperation('sorting')" :disabled="noDataFrame"/>
+              <BaseButton label="Fill missing" @add-operation="addOperation('fill_missing')" :disabled="noDataFrame"/>
               <BaseButton label="Filter" @add-operation="addOperation('filters')" :disabled="noDataFrame"/>
-              <BaseButton label="Fill Missing" @add-operation="addOperation('fill_missing')" :disabled="noDataFrame"/>
-              <BaseButton label="Group by" @add-operation="addOperation('group_by')" :disabled="hasOperation('group_by')"/>
+              <BaseButton label="Group" @add-operation="addOperation('group_by')" :disabled="hasOperation('group_by')"/>
+              <BaseButton
+                :disabled="hasOperation('pivot_wider') || hasOperation('summarise')"
+                label="Pivot wider"
+                @add-operation="addOperation('pivot_wider')"
+              />
+              <BaseButton label="Sort" @add-operation="addOperation('sorting')" :disabled="noDataFrame"/>
               <BaseButton
                 label="Summarise"
                 @add-operation="addOperation('summarise')"
-                :disabled="!hasValidGroups || hasOperation('pivot_wider')"/>
-              <BaseButton
-                :disabled="hasOperation('pivot_wider') || hasOperation('summarise')"
-                label="Pivot Wider"
-                @add-operation="addOperation('pivot_wider')"
+                :disabled="!hasValidGroups || hasOperation('pivot_wider')"
               />
             </div>
           </div>

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -544,14 +544,16 @@ export async function init(ctx, payload) {
                             :index="index"
                             :disabled="noDataFrame"
                           />
-                          <BaseSelect
-                            name="column"
+                          <BaseMultiTagSelect
+                            @change.self="addInnerValue($event)"
                             operation_type="summarise"
                             label="Columns"
-                            v-model="operation.column"
+                            v-model="operation.columns"
                             :options="dataFrameColumns"
                             :index="index"
+                            field="columns"
                             :disabled="noDataFrame"
+                            @remove-inner-value="removeInnerValue(index, 'columns', $event)"
                           />
                         </div>
                         <div class="row" v-if="operation.operation_type === 'pivot_wider'">

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -292,7 +292,7 @@ export async function init(ctx, payload) {
     },
     methods: {
       availableOptions(tags, options) {
-        return options.filter(option => !tags.includes(option));
+        return options.filter((option) => !tags.includes(option));
       },
     },
     template: `
@@ -534,6 +534,34 @@ export async function init(ctx, payload) {
                             @remove-inner-value="removeInnerValue(index, 'group_by', $event)"
                           />
                         </div>
+                        <div class="row" v-if="operation.operation_type === 'summarise'">
+                          <BaseInput
+                            name="name"
+                            operation_type="summarise"
+                            label="Name"
+                            v-model="operation.name"
+                            :index="index"
+                            :disabled="noDataFrame"
+                          />
+                          <BaseSelect
+                            name="query"
+                            operation_type="summarise"
+                            label="Query"
+                            v-model="operation.query"
+                            :options="summariseOptions"
+                            :index="index"
+                            :disabled="noDataFrame"
+                          />
+                          <BaseSelect
+                            name="column"
+                            operation_type="summarise"
+                            label="Column"
+                            v-model="operation.column"
+                            :options="dataFrameColumns"
+                            :index="index"
+                            :disabled="noDataFrame"
+                          />
+                        </div>
                         <div class="row" v-if="operation.operation_type === 'pivot_wider'">
                           <BaseSelect
                             name="names_from"
@@ -599,7 +627,11 @@ export async function init(ctx, payload) {
               <BaseButton label="Fill Missing" @add-operation="addOperation('fill_missing')" :disabled="noDataFrame"/>
               <BaseButton label="Group by" @add-operation="addOperation('group_by')" :disabled="noDataFrame"/>
               <BaseButton
-                :disabled="hasPivotWider"
+                label="Summarise"
+                @add-operation="addOperation('summarise')"
+                :disabled="!hasOperation('group_by') || hasOperation('pivot_wider')"/>
+              <BaseButton
+                :disabled="hasOperation('pivot_wider') || hasOperation('summarise')"
                 label="Pivot Wider"
                 @add-operation="addOperation('pivot_wider')"
               />
@@ -642,9 +674,10 @@ export async function init(ctx, payload) {
           string: ["forward", "backward", "max", "min", "scalar"],
           date: ["forward", "backward", "max", "min", "scalar"],
           boolean: ["forward", "backward", "max", "min", "scalar"],
-          integer:  ["forward", "backward", "max", "min", "mean", "scalar"],
+          integer: ["forward", "backward", "max", "min", "mean", "scalar"],
           float: ["forward", "backward", "max", "min", "mean", "nan", "scalar"],
-        }
+        },
+        summariseOptions: ["min", "mean", "max"],
       };
     },
 
@@ -663,14 +696,12 @@ export async function init(ctx, payload) {
       noDataFrame() {
         return !this.rootFields.data_frame;
       },
-      hasPivotWider() {
-        return this.operations.some(
-          (operation) => operation.operation_type === "pivot_wider"
-        );
-      },
     },
 
     methods: {
+      hasOperation(operation_type) {
+        return this.operations.some((operation) => operation.operation_type === operation_type)
+      },
       handleFieldChange(event) {
         const field = event.target.name;
         if (!field) return;
@@ -719,7 +750,9 @@ export async function init(ctx, payload) {
         return supportedColumns;
       },
       handleItemDrop({ removedIndex, addedIndex }) {
-        const maxAllowed = this.hasPivotWider ? this.operations.length - 2 : this.operations.length - 1;
+        const maxAllowed = this.hasPivotWider
+          ? this.operations.length - 2
+          : this.operations.length - 1;
         addedIndex = Math.min(addedIndex, maxAllowed);
         if (removedIndex === addedIndex) return;
         ctx.pushEvent("move_operation", { removedIndex, addedIndex });
@@ -737,7 +770,11 @@ export async function init(ctx, payload) {
         });
       },
       removeInnerValue(idx, field, value) {
-        ctx.pushEvent("remove_inner_value", { field, value, idx: parseInt(idx) })
+        ctx.pushEvent("remove_inner_value", {
+          field,
+          value,
+          idx: parseInt(idx),
+        });
       },
     },
   }).mount(ctx.root);

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -535,18 +535,10 @@ export async function init(ctx, payload) {
                           />
                         </div>
                         <div class="row" v-if="operation.operation_type === 'summarise'">
-                          <BaseInput
-                            name="name"
-                            operation_type="summarise"
-                            label="Name"
-                            v-model="operation.name"
-                            :index="index"
-                            :disabled="noDataFrame"
-                          />
                           <BaseSelect
                             name="query"
                             operation_type="summarise"
-                            label="Query"
+                            label="Summarise by"
                             v-model="operation.query"
                             :options="summariseOptions"
                             :index="index"
@@ -555,7 +547,7 @@ export async function init(ctx, payload) {
                           <BaseSelect
                             name="column"
                             operation_type="summarise"
-                            label="Column"
+                            label="Columns"
                             v-model="operation.column"
                             :options="dataFrameColumns"
                             :index="index"

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -9,7 +9,7 @@ defmodule KinoExplorer.DataTransformCell do
 
   @grouped_fields_operations ["filters", "fill_missing"]
   @validation_by_type [:filters, :fill_missing]
-  @as_atom ["direction", "type", "operation_type", "strategy", "name", "query"]
+  @as_atom ["direction", "type", "operation_type", "strategy", "query"]
   @filters %{
     "less" => "<",
     "less equal" => "<=",
@@ -356,9 +356,8 @@ defmodule KinoExplorer.DataTransformCell do
       for summarize <- summarization,
           summarize.column,
           summarize.query,
-          summarize.name,
           summarize.active do
-        {summarize.name, quote do
+        {String.to_atom("#{summarize.column}_#{summarize.query}"), quote do
           unquote(summarize.query)(unquote(quoted_column(summarize.column)))
         end}
       end
@@ -505,7 +504,6 @@ defmodule KinoExplorer.DataTransformCell do
     %{
       "column" => nil,
       "query" => nil,
-      "name" => nil,
       "active" => true,
       "operation_type" => "summarise"
     }

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -178,7 +178,10 @@ defmodule KinoExplorer.DataTransformCell do
     summarise = operations_by_type["summarise"]
     offset = (pivot_wider || summarise || 0) + 1
 
-    updated_operations = List.insert_at(operations, -offset, new_operation)
+    updated_operations =
+      if operation_type == "pivot_wider" or operation_type == "summarise",
+        do: operations ++ [new_operation],
+        else: List.insert_at(operations, -offset, new_operation)
 
     ctx = assign(ctx, operations: updated_operations)
     broadcast_event(ctx, "set_operations", %{"operations" => updated_operations})

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -353,12 +353,11 @@ defmodule KinoExplorer.DataTransformCell do
 
   defp to_quoted([%{operation_type: :summarise} | _] = summarization) do
     summarize_args =
-      for summarize <- summarization,
-          summarize.column,
+      for summarize <- summarization, column <- summarize.columns,
           summarize.query,
           summarize.active do
-        {String.to_atom("#{summarize.column}_#{summarize.query}"), quote do
-          unquote(summarize.query)(unquote(quoted_column(summarize.column)))
+        {String.to_atom("#{column}_#{summarize.query}"), quote do
+          unquote(summarize.query)(unquote(quoted_column(column)))
         end}
       end
       |> then(fn args -> if args != [], do: [args] end)
@@ -502,7 +501,7 @@ defmodule KinoExplorer.DataTransformCell do
 
   defp default_operation(:summarise) do
     %{
-      "column" => nil,
+      "columns" => [],
       "query" => nil,
       "active" => true,
       "operation_type" => "summarise"

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -172,13 +172,13 @@ defmodule KinoExplorer.DataTransformCell do
 
   def handle_event("add_operation", %{"operation_type" => operation_type}, ctx) do
     operations = ctx.assigns.operations
+    operations_by_type = Enum.frequencies_by(operations, & &1["operation_type"])
     new_operation = operation_type |> String.to_existing_atom() |> default_operation()
-    has_pivot_wider = Enum.any?(operations, &(&1["operation_type"] == "pivot_wider"))
+    pivot_wider = operations_by_type["pivot_wider"]
+    summarise = operations_by_type["summarise"]
+    offset = (pivot_wider || summarise || 0) + 1
 
-    updated_operations =
-      if has_pivot_wider and operation_type != "pivot_wider",
-        do: List.insert_at(operations, -2, new_operation),
-        else: operations ++ [new_operation]
+    updated_operations = List.insert_at(operations, -offset, new_operation)
 
     ctx = assign(ctx, operations: updated_operations)
     broadcast_event(ctx, "set_operations", %{"operations" => updated_operations})

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -353,14 +353,17 @@ defmodule KinoExplorer.DataTransformCell do
 
   defp to_quoted([%{operation_type: :summarise} | _] = summarization) do
     summarize_args =
-      for summarize <- summarization, column <- summarize.columns,
+      for summarize <- summarization,
+          column <- summarize.columns,
           summarize.query,
           summarize.active do
-        {String.to_atom("#{column}_#{summarize.query}"), quote do
-          unquote(summarize.query)(unquote(quoted_column(column)))
-        end}
+        {String.to_atom("#{column}_#{summarize.query}"),
+         quote do
+           unquote(summarize.query)(unquote(quoted_column(column)))
+         end}
       end
       |> then(fn args -> if args != [], do: [args] end)
+
     %{field: :summarise, name: :summarise, args: summarize_args}
   end
 
@@ -500,12 +503,7 @@ defmodule KinoExplorer.DataTransformCell do
   end
 
   defp default_operation(:summarise) do
-    %{
-      "columns" => [],
-      "query" => nil,
-      "active" => true,
-      "operation_type" => "summarise"
-    }
+    %{"columns" => [], "query" => nil, "active" => true, "operation_type" => "summarise"}
   end
 
   defp cast_typed_value(:boolean, "true"), do: {:ok, true}

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -358,6 +358,11 @@ defmodule KinoExplorer.DataTransformCell do
     %{field: :pivot_wider, name: :pivot_wider, args: pivot_wider_args}
   end
 
+  defp to_quoted([%{operation_type: :group_by, group_by: group_by, active: active}]) do
+    group_by_args = if group_by && active, do: build_group_by(group_by)
+    %{field: :group_by, name: :group_by, args: group_by_args}
+  end
+
   defp build_root(df) do
     quote do
       unquote(Macro.var(String.to_atom(df), nil))
@@ -384,6 +389,10 @@ defmodule KinoExplorer.DataTransformCell do
   defp build_pivot_wider(_names, []), do: nil
   defp build_pivot_wider(names, [values]), do: [names, values]
   defp build_pivot_wider(names, values), do: [names, values]
+
+  defp build_group_by([]), do: nil
+  defp build_group_by([group_by]), do: [group_by]
+  defp build_group_by(group_by), do: [group_by]
 
   defp build_filter([column, filter, value, type] = args) do
     with true <- Enum.all?(args, &(&1 != nil)),
@@ -471,6 +480,10 @@ defmodule KinoExplorer.DataTransformCell do
       "active" => true,
       "operation_type" => "pivot_wider"
     }
+  end
+
+  defp default_operation(:group_by) do
+    %{"group_by" => [], "active" => true, "operation_type" => "group_by"}
   end
 
   defp cast_typed_value(:boolean, "true"), do: {:ok, true}


### PR DESCRIPTION
<img width="1253" alt="Screenshot 2023-03-29 at 16 23 25" src="https://user-images.githubusercontent.com/5660941/228489932-4c2d5bd3-b652-4be5-ad54-c13eb8bd2fd0.png">
<img width="1253" alt="Screenshot 2023-03-29 at 16 33 45" src="https://user-images.githubusercontent.com/5660941/228492058-f24ac828-ce2f-4ac2-808a-ea29688dcb36.png">


`group_by` is unique and accepts multiple columns.
`summarise` and `pivot_wider` are mutually exclusive
`summarise` accepts multiple columns
`summarise` requires a valid group and columns that are not of type string or boolean
`summarise` is always grouped and always at the end
`summarise` is non-draggable

`group_by` validation is only preventive. If the user deletes the group and there's `summarise`, we let it leak to the Explorer error