### PR TITLE
Ensures that the selected item won't be shown in the select input

### DIFF
--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -872,6 +872,7 @@ select option {
 }
 
 .tag-input {
+  color: var(--gray-50);
   width: 25px;
   padding: 0 4px;
   border: none;


### PR DESCRIPTION
Small fix to prevent the currently selected item from being shown in the select input when reconnecting.