### PR TITLE
Operation options and types

### DIFF
--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -543,7 +543,7 @@ export async function init(ctx, payload) {
                             operation_type="summarise"
                             label="Summarise by"
                             v-model="operation.columns"
-                            :options="dataFrameColumnsByTypes(['integer', 'float', 'date', 'time', 'datetime'])"
+                            :options="dataFrameColumnsByTypes(summariseTypes.columns)"
                             :index="index"
                             field="columns"
                             :disabled="noDataFrame"
@@ -565,7 +565,7 @@ export async function init(ctx, payload) {
                             operation_type="pivot_wider"
                             label="Pivot names from"
                             v-model="operation.names_from"
-                            :options="dataFrameColumnsByTypes(['string'])"
+                            :options="dataFrameColumnsByTypes(pivotWiderTypes.names_from)"
                             :index="index"
                             :disabled="noDataFrame"
                           />
@@ -574,7 +574,7 @@ export async function init(ctx, payload) {
                             operation_type="pivot_wider"
                             label="Values from"
                             v-model="operation.values_from"
-                            :options="dataFrameColumnsByTypes(['integer'])"
+                            :options="dataFrameColumnsByTypes(pivotWiderTypes.values_from)"
                             :index="index"
                             field="values_from"
                             :disabled="noDataFrame"
@@ -645,36 +645,14 @@ export async function init(ctx, payload) {
         operations: payload.operations,
         dataFrames: payload.data_options,
         dataFrameVariables: payload.data_options.map((df) => df["variable"]),
+        pivotWiderTypes: payload.operation_types.pivot_wider,
+        summariseTypes: payload.operation_types.summarise,
+        fillMissingOptions: payload.operation_options.fill_missing,
+        filterOptions: payload.operation_options.filter,
         orderOptions: [
           { label: "ascending", value: "asc" },
           { label: "descending", value: "desc" },
         ],
-        filterOptions: {
-          numeric: [
-            "less",
-            "less equal",
-            "equal",
-            "not equal",
-            "greater equal",
-            "greater",
-          ],
-          categorical: ["equal", "contains", "not equal"],
-          boolean: ["equal", "not equal"],
-        },
-        columnTypes: {
-          float: "numeric",
-          integer: "numeric",
-          date: "numeric",
-          string: "categorical",
-          boolean: "boolean",
-        },
-        fillMissingOptions: {
-          string: ["forward", "backward", "max", "min", "scalar"],
-          date: ["forward", "backward", "max", "min", "scalar"],
-          boolean: ["forward", "backward", "max", "min", "scalar"],
-          integer: ["forward", "backward", "max", "min", "mean", "scalar"],
-          float: ["forward", "backward", "max", "min", "mean", "nan", "scalar"],
-        },
         summariseOptions: ["min", "mean", "max"],
       };
     },
@@ -737,14 +715,11 @@ export async function init(ctx, payload) {
       },
       filterOptionsByType(column) {
         const columnType = this.dataFrameInfo?.columns[column];
-        return this.filterOptions[this.columnTypes[columnType]];
+        return this.filterOptions[columnType];
       },
       fillMissingOptionsByType(column) {
         const columnType = this.dataFrameInfo?.columns[column];
         return this.fillMissingOptions[columnType];
-      },
-      columnType(column) {
-        return this.dataFrameInfo?.columns[column];
       },
       dataFrameColumnsByTypes(supportedTypes) {
         const dataFrameColumns = this.dataFrameInfo

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -7,6 +7,45 @@ defmodule KinoExplorer.DataTransformCell do
 
   alias Explorer.DataFrame
 
+  @column_types [
+    "binary",
+    "boolean",
+    "category",
+    "date",
+    "datetime",
+    "float",
+    "integer",
+    "string",
+    "time"
+  ]
+  @filter_options %{
+    binary: ["equal", "contains", "not equal"],
+    boolean: ["equal", "not equal"],
+    category: ["equal", "contains", "not equal"],
+    date: ["less", "less equal", "equal", "not equal", "greater equal", "greater"],
+    datetime: ["less", "less equal", "equal", "not equal", "greater equal", "greater"],
+    float: ["less", "less equal", "equal", "not equal", "greater equal", "greater"],
+    integer: ["less", "less equal", "equal", "not equal", "greater equal", "greater"],
+    string: ["equal", "contains", "not equal"],
+    time: ["less", "less equal", "equal", "not equal", "greater equal", "greater"]
+  }
+  @fill_missing_options %{
+    binary: ["forward", "backward", "max", "min", "scalar"],
+    boolean: ["forward", "backward", "max", "min", "scalar"],
+    category: ["forward", "backward", "max", "min", "scalar"],
+    date: ["forward", "backward", "max", "min", "mean", "scalar"],
+    datetime: ["forward", "backward", "max", "min", "mean", "scalar"],
+    float: ["forward", "backward", "max", "min", "mean", "scalar", "nan"],
+    integer: ["forward", "backward", "max", "min", "mean", "scalar"],
+    string: ["forward", "backward", "max", "min", "scalar"],
+    time: ["forward", "backward", "max", "min", "mean", "scalar"]
+  }
+  @pivot_wider_types %{
+    names_from: @column_types,
+    values_from: ["date", "datetime", "float", "integer", "time"]
+  }
+  @summarise_types %{columns: ["date", "datetime", "float", "integer", "time"]}
+
   @grouped_fields_operations ["filters", "fill_missing"]
   @validation_by_type [:filters, :fill_missing]
   @as_atom ["direction", "type", "operation_type", "strategy", "query"]
@@ -32,6 +71,8 @@ defmodule KinoExplorer.DataTransformCell do
         operations: operations,
         data_frame_alias: Explorer.DataFrame,
         data_options: [],
+        operation_options: %{fill_missing: @fill_missing_options, filter: @filter_options},
+        operation_types: %{pivot_wider: @pivot_wider_types, summarise: @summarise_types},
         missing_require: nil
       )
 
@@ -56,6 +97,8 @@ defmodule KinoExplorer.DataTransformCell do
       root_fields: ctx.assigns.root_fields,
       operations: ctx.assigns.operations,
       data_options: ctx.assigns.data_options,
+      operation_options: ctx.assigns.operation_options,
+      operation_types: ctx.assigns.operation_types,
       missing_require: ctx.assigns.missing_require
     }
 


### PR DESCRIPTION
Direct and explicit mapping of the operations that depend on the column type

Operation options: strategy or query supported for the operation by column type
Operation types: types supported for the operation by field