### PR TITLE
Summarise options

### DIFF
--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -885,3 +885,11 @@ select option {
 .tag-input:focus {
   border: none;
 }
+
+.tag-message {
+  opacity: 50%;
+}
+
+select.input.tag-input:disabled {
+  display: none;
+}

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -264,6 +264,10 @@ export async function init(ctx, payload) {
         type: String,
         default: "",
       },
+      message: {
+        type: String,
+        default: "",
+      },
       selectClass: {
         type: String,
         default: "input",
@@ -302,6 +306,7 @@ export async function init(ctx, payload) {
       </label>
       <div class="tags input">
         <div class="tags-wrapper">
+          <span class="tag-message" v-if="disabled">{{ message }}</span>
           <span class="tag-pill" v-for="tag in modelValue">
             {{ tag }}
             <button
@@ -546,8 +551,9 @@ export async function init(ctx, payload) {
                             :options="dataFrameColumnsByTypes(summariseOptions[operation.query])"
                             :index="index"
                             field="columns"
-                            :disabled="noDataFrame"
+                            :disabled="!operation.query"
                             @remove-inner-value="removeInnerValue(index, 'columns', $event)"
+                            message="Select a summarise 'using' first"
                           />
                           <BaseSelect
                             name="query"

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -543,7 +543,7 @@ export async function init(ctx, payload) {
                             operation_type="summarise"
                             label="Summarise by"
                             v-model="operation.columns"
-                            :options="dataFrameColumnsByTypes(summariseTypes.columns)"
+                            :options="dataFrameColumnsByTypes(summariseOptions[operation.query])"
                             :index="index"
                             field="columns"
                             :disabled="noDataFrame"
@@ -554,7 +554,7 @@ export async function init(ctx, payload) {
                             operation_type="summarise"
                             label="Using"
                             v-model="operation.query"
-                            :options="summariseOptions"
+                            :options="summariseUsingOptions"
                             :index="index"
                             :disabled="noDataFrame"
                           />
@@ -649,11 +649,12 @@ export async function init(ctx, payload) {
         summariseTypes: payload.operation_types.summarise,
         fillMissingOptions: payload.operation_options.fill_missing,
         filterOptions: payload.operation_options.filter,
+        summariseOptions: payload.operation_options.summarise,
+        summariseUsingOptions: Object.keys(payload.operation_options.summarise),
         orderOptions: [
           { label: "ascending", value: "asc" },
           { label: "descending", value: "desc" },
         ],
-        summariseOptions: ["min", "mean", "max"],
       };
     },
 
@@ -721,7 +722,8 @@ export async function init(ctx, payload) {
         const columnType = this.dataFrameInfo?.columns[column];
         return this.fillMissingOptions[columnType];
       },
-      dataFrameColumnsByTypes(supportedTypes) {
+      dataFrameColumnsByTypes(columnTypes) {
+        const supportedTypes = columnTypes ? columnTypes : [];
         const dataFrameColumns = this.dataFrameInfo
           ? this.dataFrameInfo.columns
           : {};


### PR DESCRIPTION
All aggregations except `frequencies` and `quantile` 

- Automatically filters supported columns by `using`
- Cleans columns after changing `using`
- Message when there's no `using` (we could use a default `using` instead, WDYT @josevalim ?)

<img width="1442" alt="Screenshot 2023-04-04 at 11 39 01" src="https://user-images.githubusercontent.com/5660941/229688674-1bd7dbba-ba51-445c-a4d0-bf7784befc98.png">

<img width="1442" alt="Screenshot 2023-04-04 at 11 39 10" src="https://user-images.githubusercontent.com/5660941/229688699-7d83a132-d828-4433-8d07-392d1f148d1c.png">
