### PR TITLE
Allow summarise anywhere

### DIFF
--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -418,8 +418,7 @@ select option {
   cursor: move;
 }
 
-.card.pivot_wider:hover,
-.card.summarise:hover {
+.card.pivot_wider:hover {
   cursor: default;
 }
 

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -469,7 +469,7 @@ export async function init(ctx, payload) {
               <Container @drop="handleItemDrop" lock-axis="y" non-drag-area-selector=".field">
                 <Draggable
                   v-for="(operation, index) in operations"
-                  :drag-not-allowed="operation.operation_type === 'pivot_wider' || operation.operation_type === 'summarise'"
+                  :drag-not-allowed="operation.operation_type === 'pivot_wider'"
                 >
                   <div :class="['operations', operation.operation_type]">
                     <BaseCard
@@ -842,11 +842,7 @@ export async function init(ctx, payload) {
         return supportedColumns;
       },
       handleItemDrop({ removedIndex, addedIndex }) {
-        const offset = this.operations.filter(
-          (operation) =>
-            operation.operation_type === "pivot_wider" ||
-            operation.operation_type === "summarise"
-        ).length;
+        const offset = this.operations.filter((operation) => operation.operation_type === "pivot_wider").length;
         const maxAllowed = this.operations.length - offset - 1;
         addedIndex = Math.min(addedIndex, maxAllowed);
         if (removedIndex === addedIndex) return;

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -497,7 +497,7 @@ export async function init(ctx, payload) {
                             operation_type="filters"
                             label="Filter by"
                             v-model="operation.column"
-                            :options="dataFrameColumnsWithTypes"
+                            :options="dataFrameColumnsWithTypes(operation.data_options)"
                             :disabled="noDataFrame"
                             :index="index"
                           />
@@ -506,7 +506,7 @@ export async function init(ctx, payload) {
                             operation_type="filters"
                             label="Operation"
                             v-model="operation.filter"
-                            :options="filterOptionsByType(operation.column)"
+                            :options="filterOptionsByType(operation.column, operation.data_options)"
                             :required
                             :disabled="!operation.column"
                             :index="index"
@@ -570,7 +570,7 @@ export async function init(ctx, payload) {
                             operation_type="fill_missing"
                             label="Fill missing"
                             v-model="operation.column"
-                            :options="dataFrameColumns"
+                            :options="dataFrameColumns(operation.data_options)"
                             :index="index"
                             :disabled="noDataFrame"
                           />
@@ -579,7 +579,7 @@ export async function init(ctx, payload) {
                             operation_type="fill_missing"
                             label="With"
                             v-model="operation.strategy"
-                            :options="fillMissingOptionsByType(operation.column)"
+                            :options="fillMissingOptionsByType(operation.column, operation.data_options)"
                             :required
                             :index="index"
                             :disabled="!operation.column"
@@ -616,7 +616,7 @@ export async function init(ctx, payload) {
                             operation_type="sorting"
                             label="Sort by"
                             v-model="operation.sort_by"
-                            :options="dataFrameColumns"
+                            :options="dataFrameColumns(operation.data_options)"
                             :index="index"
                             :disabled="noDataFrame"
                           />
@@ -637,7 +637,7 @@ export async function init(ctx, payload) {
                             operation_type="group_by"
                             label="Group by"
                             v-model="operation.group_by"
-                            :options="dataFrameColumns"
+                            :options="dataFrameColumns(operation.data_options)"
                             :index="index"
                             field="group_by"
                             :disabled="noDataFrame"
@@ -659,7 +659,7 @@ export async function init(ctx, payload) {
                             operation_type="summarise"
                             label="Of columns"
                             v-model="operation.columns"
-                            :options="dataFrameColumnsByTypes(summariseOptions[operation.query])"
+                            :options="dataFrameColumnsByTypes(summariseOptions[operation.query], operation.data_options)"
                             :index="index"
                             field="columns"
                             :disabled="!operation.query"
@@ -673,7 +673,7 @@ export async function init(ctx, payload) {
                             operation_type="pivot_wider"
                             label="Pivot names from"
                             v-model="operation.names_from"
-                            :options="dataFrameColumnsByTypes(pivotWiderTypes.names_from)"
+                            :options="dataFrameColumnsByTypes(pivotWiderTypes.names_from, operation.data_options)"
                             :index="index"
                             :disabled="noDataFrame"
                           />
@@ -682,7 +682,7 @@ export async function init(ctx, payload) {
                             operation_type="pivot_wider"
                             label="Values from"
                             v-model="operation.values_from"
-                            :options="dataFrameColumnsByTypes(pivotWiderTypes.values_from)"
+                            :options="dataFrameColumnsByTypes(pivotWiderTypes.values_from, operation.data_options)"
                             :index="index"
                             field="values_from"
                             :disabled="noDataFrame"
@@ -751,8 +751,7 @@ export async function init(ctx, payload) {
       return {
         rootFields: payload.root_fields,
         operations: payload.operations,
-        dataFrames: payload.data_options,
-        dataFrameVariables: payload.data_options.map((df) => df["variable"]),
+        dataFrameVariables: payload.data_frames_variables,
         pivotWiderTypes: payload.operation_types.pivot_wider,
         summariseTypes: payload.operation_types.summarise,
         queriedFilterTypes: payload.operation_types.queried_filter,
@@ -769,26 +768,6 @@ export async function init(ctx, payload) {
     },
 
     computed: {
-      dataFrameInfo() {
-        const dataFrameVariable = this.rootFields.data_frame;
-        const dataFrame = this.dataFrames.find(
-          (df) => df["variable"] === dataFrameVariable
-        );
-        return dataFrame;
-      },
-      dataFrameColumns() {
-        const dataFrame = this.dataFrameInfo;
-        return dataFrame ? Object.keys(dataFrame["columns"]) : [];
-      },
-      dataFrameColumnsWithTypes() {
-        const dataFrameColumns = this.dataFrameInfo
-          ? Object.entries(this.dataFrameInfo.columns)
-          : {};
-        const columns = Array.from(dataFrameColumns, ([name, type]) => {
-          return { label: `${name} (${type})`, value: name };
-        });
-        return columns;
-      },
       noDataFrame() {
         return !this.rootFields.data_frame;
       },
@@ -801,6 +780,16 @@ export async function init(ctx, payload) {
     },
 
     methods: {
+      dataFrameColumns(data_options) {
+        return data_options ? Object.keys(data_options) : [];
+      },
+      dataFrameColumnsWithTypes(data_options) {
+        const dataFrameColumns = data_options ? Object.entries(data_options) : {};
+        const columns = Array.from(dataFrameColumns, ([name, type]) => {
+          return { label: `${name} (${type})`, value: name };
+        });
+        return columns;
+      },
       hasOperation(operation_type) {
         return this.operations.some(
           (operation) => operation.operation_type === operation_type
@@ -836,19 +825,17 @@ export async function init(ctx, payload) {
       isQueriedFilter(type) {
         return this.queriedFilterTypes.includes(type);
       },
-      filterOptionsByType(column) {
-        const columnType = this.dataFrameInfo?.columns[column];
-        return this.filterOptions[columnType];
+      filterOptionsByType(column, data_options) {
+        const columnType = data_options ? data_options[column] : null;
+        return columnType ? this.filterOptions[columnType] : [];
       },
-      fillMissingOptionsByType(column) {
-        const columnType = this.dataFrameInfo?.columns[column];
-        return this.fillMissingOptions[columnType];
+      fillMissingOptionsByType(column, data_options) {
+        const columnType = data_options ? data_options[column] : null;
+        return columnType ? this.fillMissingOptions[columnType] : [];
       },
-      dataFrameColumnsByTypes(columnTypes) {
+      dataFrameColumnsByTypes(columnTypes, data_options) {
         const supportedTypes = columnTypes ? columnTypes : [];
-        const dataFrameColumns = this.dataFrameInfo
-          ? this.dataFrameInfo.columns
-          : {};
+        const dataFrameColumns = data_options ? data_options : {};
         const supportedColumns = Object.entries(dataFrameColumns)
           .filter(([col, type]) => supportedTypes.includes(type))
           .map(([col, type]) => col);
@@ -901,8 +888,7 @@ export async function init(ctx, payload) {
   });
 
   ctx.handleEvent("set_available_data", ({ data_options, fields }) => {
-    app.dataFrameVariables = data_options.map((df) => df["variable"]);
-    app.dataFrames = data_options;
+    app.dataFrameVariables = data_options;
     setRootValues(fields.root_fields);
   });
 

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -883,8 +883,8 @@ export async function init(ctx, payload) {
     setRootValues(fields.root_fields);
   });
 
-  ctx.handleEvent("set_available_data", ({ data_options, fields }) => {
-    app.dataFrameVariables = data_options;
+  ctx.handleEvent("set_available_data", ({ data_frame_variables, fields }) => {
+    app.dataFrameVariables = data_frame_variables;
     setRootValues(fields.root_fields);
   });
 

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -731,7 +731,7 @@ export async function init(ctx, payload) {
               <BaseButton label="Filter" @add-operation="addOperation('filters')" :disabled="noDataFrame"/>
               <BaseButton label="Group" @add-operation="addOperation('group_by')" :disabled="hasOperation('group_by')"/>
               <BaseButton
-                :disabled="hasOperation('pivot_wider') || hasOperation('summarise')"
+                :disabled="hasOperation('pivot_wider')"
                 label="Pivot wider"
                 @add-operation="addOperation('pivot_wider')"
               />
@@ -739,7 +739,7 @@ export async function init(ctx, payload) {
               <BaseButton
                 label="Summarise"
                 @add-operation="addOperation('summarise')"
-                :disabled="!hasValidGroups || hasOperation('pivot_wider')"
+                :disabled="!hasValidGroups"
               />
             </div>
           </div>

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -727,19 +727,19 @@ export async function init(ctx, payload) {
               </Container>
             </div>
             <div class="add-operation">
-              <BaseButton label="Fill missing" @add-operation="addOperation('fill_missing')" :disabled="noDataFrame"/>
-              <BaseButton label="Filter" @add-operation="addOperation('filters')" :disabled="noDataFrame"/>
-              <BaseButton label="Group" @add-operation="addOperation('group_by')" :disabled="noDataFrame"/>
+              <BaseButton label="Fill missing" @add-operation="addOperation('fill_missing')" :disabled="noDataFrame || noAvailableData"/>
+              <BaseButton label="Filter" @add-operation="addOperation('filters')" :disabled="noDataFrame || noAvailableData"/>
+              <BaseButton label="Group" @add-operation="addOperation('group_by')" :disabled="noDataFrame || noAvailableData"/>
               <BaseButton
-                :disabled="hasOperation('pivot_wider')"
+                :disabled="hasOperation('pivot_wider') || noDataFrame || noAvailableData"
                 label="Pivot wider"
                 @add-operation="addOperation('pivot_wider')"
               />
-              <BaseButton label="Sort" @add-operation="addOperation('sorting')" :disabled="noDataFrame"/>
+              <BaseButton label="Sort" @add-operation="addOperation('sorting')" :disabled="noDataFrame || noAvailableData"/>
               <BaseButton
                 label="Summarise"
                 @add-operation="addOperation('summarise')"
-                :disabled="!hasValidGroups"
+                :disabled="!hasValidGroups || noDataFrame ||noAvailableData"
               />
             </div>
           </div>
@@ -771,6 +771,10 @@ export async function init(ctx, payload) {
       noDataFrame() {
         return !this.rootFields.data_frame;
       },
+      noAvailableData() {
+        const dataFrame = this.rootFields.data_frame;
+        return dataFrame ? !this.dataFrameVariables.includes(dataFrame) : true;
+      },
       hasValidGroups() {
         const groups = this.operations.find(
           (operation) => operation.operation_type === "group_by"
@@ -784,7 +788,9 @@ export async function init(ctx, payload) {
         return data_options ? Object.keys(data_options) : [];
       },
       dataFrameColumnsWithTypes(data_options) {
-        const dataFrameColumns = data_options ? Object.entries(data_options) : {};
+        const dataFrameColumns = data_options
+          ? Object.entries(data_options)
+          : {};
         const columns = Array.from(dataFrameColumns, ([name, type]) => {
           return { label: `${name} (${type})`, value: name };
         });
@@ -842,7 +848,9 @@ export async function init(ctx, payload) {
         return supportedColumns;
       },
       handleItemDrop({ removedIndex, addedIndex }) {
-        const offset = this.operations.filter((operation) => operation.operation_type === "pivot_wider").length;
+        const offset = this.operations.filter(
+          (operation) => operation.operation_type === "pivot_wider"
+        ).length;
         const maxAllowed = this.operations.length - offset - 1;
         addedIndex = Math.min(addedIndex, maxAllowed);
         if (removedIndex === addedIndex) return;

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -729,7 +729,7 @@ export async function init(ctx, payload) {
             <div class="add-operation">
               <BaseButton label="Fill missing" @add-operation="addOperation('fill_missing')" :disabled="noDataFrame"/>
               <BaseButton label="Filter" @add-operation="addOperation('filters')" :disabled="noDataFrame"/>
-              <BaseButton label="Group" @add-operation="addOperation('group_by')" :disabled="hasOperation('group_by')"/>
+              <BaseButton label="Group" @add-operation="addOperation('group_by')" :disabled="noDataFrame"/>
               <BaseButton
                 :disabled="hasOperation('pivot_wider')"
                 label="Pivot wider"

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -874,10 +874,6 @@ export async function init(ctx, payload) {
     setRootValues(fields);
   });
 
-  ctx.handleEvent("update_operation", ({ idx, fields }) => {
-    setOperationValues(idx, fields);
-  });
-
   ctx.handleEvent("update_data_frame", ({ fields }) => {
     setOperations(fields.operations);
     setRootValues(fields.root_fields);
@@ -895,12 +891,6 @@ export async function init(ctx, payload) {
   function setRootValues(fields) {
     for (const field in fields) {
       app.rootFields[field] = fields[field];
-    }
-  }
-
-  function setOperationValues(idx, fields) {
-    for (const field in fields) {
-      app.operations[idx][field] = fields[field];
     }
   }
 

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -751,7 +751,7 @@ export async function init(ctx, payload) {
       return {
         rootFields: payload.root_fields,
         operations: payload.operations,
-        dataFrameVariables: payload.data_frames_variables,
+        dataFrameVariables: payload.data_frame_variables,
         pivotWiderTypes: payload.operation_types.pivot_wider,
         summariseTypes: payload.operation_types.summarise,
         queriedFilterTypes: payload.operation_types.queried_filter,

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -98,7 +98,7 @@ defmodule KinoExplorer.DataTransformCell do
         root_fields: root_fields,
         operations: operations,
         data_frame_alias: Explorer.DataFrame,
-        data_frames_variables: [],
+        data_frame_variables: [],
         operation_options: %{
           fill_missing: @fill_missing_options,
           filter: @filter_options,
@@ -127,7 +127,7 @@ defmodule KinoExplorer.DataTransformCell do
     payload = %{
       root_fields: ctx.assigns.root_fields,
       operations: ctx.assigns.operations,
-      data_frames_variables: ctx.assigns.data_frames_variables,
+      data_frame_variables: ctx.assigns.data_frame_variables,
       operation_options: ctx.assigns.operation_options,
       operation_types: ctx.assigns.operation_types,
       missing_require: ctx.assigns.missing_require
@@ -148,19 +148,19 @@ defmodule KinoExplorer.DataTransformCell do
             data: val
           }
 
-    data_frames_variables = Enum.map(data_frames, & &1.variable)
+    data_frame_variables = Enum.map(data_frames, & &1.variable)
 
     ctx =
       assign(ctx,
         binding: binding,
         data_frames: data_frames,
-        data_frames_variables: data_frames_variables,
+        data_frame_variables: data_frame_variables,
         data_frame_alias: data_frame_alias,
         missing_require: missing_require
       )
 
     updated_fields =
-      case {ctx.assigns.root_fields["data_frame"], data_frames_variables} do
+      case {ctx.assigns.root_fields["data_frame"], data_frame_variables} do
         {nil, [data_frame | _]} -> updates_for_data_frame(data_frame, ctx)
         _ -> %{}
       end
@@ -168,7 +168,7 @@ defmodule KinoExplorer.DataTransformCell do
     ctx = if updated_fields == %{}, do: ctx, else: assign(ctx, updated_fields)
 
     broadcast_event(ctx, "set_available_data", %{
-      "data_frames_variables" => data_frames_variables,
+      "data_frame_variables" => data_frame_variables,
       "fields" => updated_fields
     })
 

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -163,11 +163,17 @@ defmodule KinoExplorer.DataTransformCell do
 
     updated_fields =
       case {ctx.assigns.root_fields["data_frame"], data_frame_variables} do
-        {nil, [data_frame | _]} -> updates_for_data_frame(data_frame, ctx)
-        _ -> %{}
+        {nil, [data_frame | _]} ->
+          updates_for_data_frame(data_frame, ctx)
+
+        _ ->
+          %{
+            root_fields: ctx.assigns.root_fields,
+            operations: update_data_options(ctx.assigns.operations, ctx)
+          }
       end
 
-    ctx = if updated_fields == %{}, do: ctx, else: assign(ctx, updated_fields)
+    ctx = assign(ctx, updated_fields)
 
     broadcast_event(ctx, "set_available_data", %{
       "data_frame_variables" => data_frame_variables,

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -743,8 +743,12 @@ defmodule KinoExplorer.DataTransformCell do
 
     if binding != [] do
       for {operation, idx} <- Enum.with_index(operations) do
-        offset = Enum.at(offsets, idx)
-        partial_operations = if idx > 0, do: Enum.slice(operations, 0..(idx + 1 - offset)), else: []
+        offset = if operation["operation_type"] == "filters", do: 1, else: Enum.at(offsets, idx)
+
+        partial_operations =
+          if idx - offset >= 0 and idx > 0,
+            do: Enum.slice(operations, 0..(idx - offset)),
+            else: []
 
         df =
           to_partial_attrs(ctx, partial_operations)

--- a/test/kino_explorer/data_transform_cell_test.exs
+++ b/test/kino_explorer/data_transform_cell_test.exs
@@ -79,23 +79,26 @@ defmodule KinoExplorer.DataTransformCellTest do
     env = Code.env_for_eval([])
     DataTransformCell.scan_binding(kino.pid, binding(), env)
 
-    data_options = [
-      %{
-        columns: %{"id" => :integer, "name" => :string},
-        distinct: %{"name" => ["Amy Santiago", "Jake Peralta", "Terry Jeffords"]},
-        variable: "people"
-      },
-      %{
-        columns: %{"hour" => :integer, "team" => :string, "weekday" => :string},
-        distinct: %{
-          "team" => ["A", "B", "C"],
-          "weekday" => ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
-        },
-        variable: "teams"
-      }
-    ]
+    data_frame_variables = ["people", "teams"]
 
-    assert_broadcast_event(kino, "set_available_data", %{"data_options" => ^data_options})
+    assert_broadcast_event(kino, "set_available_data", %{
+      "data_frame_variables" => ^data_frame_variables,
+      "fields" => %{
+        operations: [
+          %{
+            "active" => true,
+            "column" => nil,
+            "data_options" => %{"id" => :integer, "name" => :string},
+            "datalist" => [],
+            "filter" => nil,
+            "operation_type" => "filters",
+            "type" => "string",
+            "value" => nil
+          }
+        ],
+        root_fields: %{"assign_to" => nil, "data_frame" => "people"}
+      }
+    })
   end
 
   describe "code generation" do


### PR DESCRIPTION
@josevalim You can already play with it, but I still need to do some adjustments

<img width="925" alt="Screenshot 2023-04-17 at 23 37 55" src="https://user-images.githubusercontent.com/5660941/232553236-fe01020d-1fb7-4f06-a7b6-5ac25d9e27f5.png">


https://user-images.githubusercontent.com/5660941/232553305-cbcd1d03-8b71-45ac-92b7-eead036f6b06.mp4

It respects grouped operations, so if we have two `summarises` in a row, the second one will have access to the `data_options` and the groups in the data frame prior to the summarization

https://user-images.githubusercontent.com/5660941/232554568-c1a11d06-8287-4a13-bc36-c111d5d77160.mp4


