### PR TITLE
ignore nil when doing series top summeries

### DIFF
--- a/lib/kino/explorer.ex
+++ b/lib/kino/explorer.ex
@@ -111,7 +111,7 @@ defmodule Kino.Explorer do
         top_freq = top_freq |> List.first() |> to_string()
         top = List.first(top) || ""
         unique = count_unique(series)
-        keys = ["unique", "top", "top_freq", "nulls"]
+        keys = ["unique", "top", "top freq", "nulls"]
         values = [unique, top, top_freq, nulls]
 
         keys = if has_groups, do: keys ++ ["grouped"], else: keys
@@ -124,6 +124,7 @@ defmodule Kino.Explorer do
 
   defp most_frequent(data) do
     data
+    |> Series.mask(Series.is_not_nil(data))
     |> Series.frequencies()
     |> DataFrame.head(1)
     |> DataFrame.to_columns()

--- a/lib/kino/explorer.ex
+++ b/lib/kino/explorer.ex
@@ -110,7 +110,7 @@ defmodule Kino.Explorer do
       else
         %{"counts" => top_freq, "values" => top} = most_frequent(series)
         top_freq = top_freq |> List.first() |> to_string()
-        top = List.first(top) || ""
+        top = List.first(top) |> to_string()
         unique = count_unique(series)
         keys = ["unique", "top", "top freq", "nulls"]
         values = [unique, top, top_freq, nulls]

--- a/lib/kino/explorer.ex
+++ b/lib/kino/explorer.ex
@@ -11,6 +11,7 @@ defmodule Kino.Explorer do
 
   alias Explorer.DataFrame
   alias Explorer.Series
+  require Explorer.DataFrame
 
   @behaviour Kino.Table
 
@@ -124,8 +125,9 @@ defmodule Kino.Explorer do
 
   defp most_frequent(data) do
     data
-    |> Series.mask(Series.is_not_nil(data))
     |> Series.frequencies()
+    |> DataFrame.head(2)
+    |> DataFrame.filter(Series.is_not_nil(values))
     |> DataFrame.head(1)
     |> DataFrame.to_columns()
   end

--- a/test/kino/explorer_test.exs
+++ b/test/kino/explorer_test.exs
@@ -138,6 +138,32 @@ defmodule Kino.ExplorerTest do
            } = data
   end
 
+  test "support data summary for all nils" do
+    df =
+      Explorer.DataFrame.new(%{
+        id: [nil, nil, nil, nil],
+      })
+
+    widget = Kino.Explorer.new(df)
+    data = connect(widget)
+
+    assert %{
+             content: %{
+               columns: [
+                 %{
+                   key: "0",
+                   label: "id",
+                   summary: %{
+                     keys: ["min", "max", "mean", "nulls"],
+                     values: ["", "", "", "4"]
+                   },
+                   type: "number"
+                 }
+               ]
+             }
+           } = data
+  end
+
   test "shows if a column is in a group when there are groups" do
     df =
       Explorer.DataFrame.new(%{

--- a/test/kino/explorer_test.exs
+++ b/test/kino/explorer_test.exs
@@ -106,7 +106,8 @@ defmodule Kino.ExplorerTest do
     df =
       Explorer.DataFrame.new(%{
         id: [3, 1, 2, nil, nil, nil, nil],
-        name: ["Amy Santiago", "Jake Peralta", "Terry Jeffords", "Jake Peralta", nil, nil, nil]
+        name: ["Amy Santiago", "Jake Peralta", "Terry Jeffords", "Jake Peralta", nil, nil, nil],
+        woman: [true, false, false, false, nil, nil, nil]
       })
 
     widget = Kino.Explorer.new(df)
@@ -132,6 +133,15 @@ defmodule Kino.ExplorerTest do
                      values: ["4", "Jake Peralta", "2", "3"]
                    },
                    type: "text"
+                 },
+                 %{
+                   key: "2",
+                   label: "woman",
+                   summary: %{
+                     keys: ["unique", "top", "top freq", "nulls"],
+                     values: ["3", "false", "3", "3"]
+                   },
+                   type: "boolean"
                  }
                ]
              }
@@ -141,7 +151,7 @@ defmodule Kino.ExplorerTest do
   test "support data summary for all nils" do
     df =
       Explorer.DataFrame.new(%{
-        id: [nil, nil, nil, nil],
+        id: [nil, nil, nil, nil]
       })
 
     widget = Kino.Explorer.new(df)

--- a/test/kino/explorer_test.exs
+++ b/test/kino/explorer_test.exs
@@ -105,8 +105,8 @@ defmodule Kino.ExplorerTest do
   test "supports data summary" do
     df =
       Explorer.DataFrame.new(%{
-        id: [3, 1, 2, nil],
-        name: ["Amy Santiago", "Jake Peralta", "Terry Jeffords", "Jake Peralta"]
+        id: [3, 1, 2, nil, nil, nil, nil],
+        name: ["Amy Santiago", "Jake Peralta", "Terry Jeffords", "Jake Peralta", nil, nil, nil]
       })
 
     widget = Kino.Explorer.new(df)
@@ -120,7 +120,7 @@ defmodule Kino.ExplorerTest do
                    label: "id",
                    summary: %{
                      keys: ["min", "max", "mean", "nulls"],
-                     values: ["1", "3", "2.0", "1"]
+                     values: ["1", "3", "2.0", "4"]
                    },
                    type: "number"
                  },
@@ -128,8 +128,8 @@ defmodule Kino.ExplorerTest do
                    key: "1",
                    label: "name",
                    summary: %{
-                     keys: ["unique", "top", "top_freq", "nulls"],
-                     values: ["3", "Jake Peralta", "2", "0"]
+                     keys: ["unique", "top", "top freq", "nulls"],
+                     values: ["4", "Jake Peralta", "2", "3"]
                    },
                    type: "text"
                  }
@@ -165,7 +165,7 @@ defmodule Kino.ExplorerTest do
                    key: "1",
                    label: "name",
                    summary: %{
-                     keys: ["unique", "top", "top_freq", "nulls", "grouped"],
+                     keys: ["unique", "top", "top freq", "nulls", "grouped"],
                      values: ["3", "Jake Peralta", "2", "0", "true"]
                    },
                    type: "text"


### PR DESCRIPTION
Add a nil filter to the series before doing summaries, also changed top_freq to top freq as mentioned in #70
I changed the existing summaries test to include some nils to test this, if you prefer I can also create a new test


closes #70 