### PR TITLE
Emit lazy by default

### DIFF
--- a/lib/assets/data_transform_cell/main.css
+++ b/lib/assets/data_transform_cell/main.css
@@ -163,6 +163,12 @@ input[type="number"] {
   flex-grow: 1;
   margin-bottom: 0;
   max-width: 350px;
+  min-width: auto;
+}
+
+.root-group {
+  display: flex;
+  gap: 16px;
 }
 
 .special-field {
@@ -799,7 +805,7 @@ select option {
 
 .switch-button-checkbox:disabled {
   background: white;
-  border-color: var(--blue-100);
+  border-color: var(--blue-200);
 }
 
 .switch-button-checkbox.filters:disabled {
@@ -838,7 +844,7 @@ select option {
 }
 
 .switch-button-checkbox:disabled + .switch-button-bg {
-  background-color: var(--blue-100);
+  background-color: var(--blue-200);
 }
 
 .switch-button-checkbox.filters:disabled + .switch-button-bg {

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -411,17 +411,10 @@ export async function init(ctx, payload) {
               />
               <div class="root-group">
                 <BaseSwitch
-                  name="lazy"
-                  label="Lazy"
-                  v-model="rootFields.lazy"
-                  :disabled="noDataFrame"
-                  class="root-field"
-                />
-                <BaseSwitch
                   name="collect"
                   label="Collect"
                   v-model="rootFields.collect"
-                  :disabled="noDataFrame || !rootFields.lazy"
+                  :disabled="noDataFrame"
                   class="root-field"
                 />
               </div>

--- a/lib/assets/data_transform_cell/main.js
+++ b/lib/assets/data_transform_cell/main.js
@@ -409,6 +409,22 @@ export async function init(ctx, payload) {
                 :disabled="noDataFrame"
                 class="root-field"
               />
+              <div class="root-group">
+                <BaseSwitch
+                  name="lazy"
+                  label="Lazy"
+                  v-model="rootFields.lazy"
+                  :disabled="noDataFrame"
+                  class="root-field"
+                />
+                <BaseSwitch
+                  name="collect"
+                  label="Collect"
+                  v-model="rootFields.collect"
+                  :disabled="noDataFrame || !rootFields.lazy"
+                  class="root-field"
+                />
+              </div>
             </div>
             <!-- Operations -->
             <div class="pipeline">

--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -543,7 +543,10 @@ defmodule KinoExplorer.DataTransformCell do
 
   defp maybe_collect(nodes, _, _), do: nodes
 
-  defp maybe_clean_up(nodes, %{is_data_frame: false}), do: nodes
+  defp maybe_clean_up([%{args: [[lazy: true]]} = new, %{field: :collect} | nodes], _) do
+    [%{new | args: []} | nodes]
+  end
+
   defp maybe_clean_up([%{field: :to_lazy}, %{field: :collect} | nodes], _), do: nodes
 
   defp maybe_clean_up(nodes, _) do

--- a/test/kino_explorer/data_transform_cell_test.exs
+++ b/test/kino_explorer/data_transform_cell_test.exs
@@ -1931,7 +1931,7 @@ defmodule KinoExplorer.DataTransformCellTest do
       |> Map.delete(:pivot_wider)
       |> Map.values()
       |> List.flatten()
-      |> then(& &1 ++ pivot_wider)
+      |> then(&(&1 ++ pivot_wider))
 
     Map.put(root_attrs, "operations", operations)
   end

--- a/test/kino_explorer/data_transform_cell_test.exs
+++ b/test/kino_explorer/data_transform_cell_test.exs
@@ -164,7 +164,7 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, %{})
 
       assert DataTransformCell.to_source(attrs) == """
-             simple_data |> Explorer.DataFrame.new(lazy: true) |> Explorer.DataFrame.collect()\
+             simple_data |> Explorer.DataFrame.new()\
              """
     end
 
@@ -1341,6 +1341,27 @@ defmodule KinoExplorer.DataTransformCellTest do
 
       assert DataTransformCell.to_source(attrs) == """
              teams |> DF.pivot_wider("weekdays", "hour")\
+             """
+    end
+
+    test "does not generate noop for data when a pivot_wider is the only operation" do
+      root = %{"data_frame" => "teams", "data_frame_alias" => DF, "is_data_frame" => false}
+
+      operations = %{
+        pivot_wider: [
+          %{
+            "names_from" => "weekdays",
+            "values_from" => "hour",
+            "active" => true,
+            "operation_type" => "pivot_wider"
+          }
+        ]
+      }
+
+      attrs = build_attrs(root, operations)
+
+      assert DataTransformCell.to_source(attrs) == """
+             teams |> DF.new() |> DF.pivot_wider("weekdays", "hour")\
              """
     end
   end

--- a/test/kino_explorer/data_transform_cell_test.exs
+++ b/test/kino_explorer/data_transform_cell_test.exs
@@ -10,8 +10,7 @@ defmodule KinoExplorer.DataTransformCellTest do
   @root %{
     "data_frame" => "people",
     "assign_to" => nil,
-    "lazy" => false,
-    "collect" => false,
+    "collect" => true,
     "data_frame_alias" => Explorer.DataFrame,
     "missing_require" => nil,
     "is_data_frame" => true
@@ -64,8 +63,7 @@ defmodule KinoExplorer.DataTransformCellTest do
   @base_attrs %{
     "assign_to" => nil,
     "data_frame" => "teams",
-    "lazy" => false,
-    "collect" => false,
+    "collect" => true,
     "data_frame_alias" => Explorer.DataFrame,
     "missing_require" => nil,
     "operations" => []
@@ -166,7 +164,7 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, %{})
 
       assert DataTransformCell.to_source(attrs) == """
-             simple_data |> Explorer.DataFrame.new()\
+             simple_data |> Explorer.DataFrame.new(lazy: true) |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -184,7 +182,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.arrange(asc: name)\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.arrange(asc: name)
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -208,7 +209,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.arrange(asc: name, desc: id)\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.arrange(asc: name, desc: id)
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -228,7 +232,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.filter(name == "Ana")\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.filter(name == "Ana")
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -256,7 +263,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.filter(name == "Ana" and id < 2)\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.filter(name == "Ana" and id < 2)
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -284,7 +294,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.filter(name == "Ana")\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.filter(name == "Ana")
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -304,7 +317,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.filter(id > mean(id))\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.filter(id > mean(id))
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -332,7 +348,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.filter(id < median(id) and id > mean(id))\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.filter(id < median(id) and id > mean(id))
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -376,7 +395,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.filter(id < median(id) and id > mean(id))\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.filter(id < median(id) and id > mean(id))
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -396,7 +418,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.filter(id > quantile(id, 0.1))\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.filter(id > quantile(id, 0.1))
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -424,7 +449,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.filter(id < quantile(id, 0.5) and id > quantile(id, 0.1))\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.filter(id < quantile(id, 0.5) and id > quantile(id, 0.1))
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -476,7 +504,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.filter(id < quantile(id, 0.5) and id > quantile(id, 0.1))\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.filter(id < quantile(id, 0.5) and id > quantile(id, 0.1))
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -496,7 +527,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.mutate(name: fill_missing(name, :forward))\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.mutate(name: fill_missing(name, :forward))
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -525,7 +559,9 @@ defmodule KinoExplorer.DataTransformCellTest do
 
       assert DataTransformCell.to_source(attrs) == """
              people
-             |> Explorer.DataFrame.mutate(name: fill_missing(name, :forward), id: fill_missing(id, 4))\
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.mutate(name: fill_missing(name, :forward), id: fill_missing(id, 4))
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -553,7 +589,10 @@ defmodule KinoExplorer.DataTransformCellTest do
         })
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> Explorer.DataFrame.mutate(name: fill_missing(name, "Ana"))\
+             people
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.mutate(name: fill_missing(name, "Ana"))
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -600,8 +639,10 @@ defmodule KinoExplorer.DataTransformCellTest do
       assert DataTransformCell.to_source(attrs) == """
              new_df =
                df
+               |> Explorer.DataFrame.to_lazy()
                |> Explorer.DataFrame.filter(col("full name") == "Ana" and id < 2)
-               |> Explorer.DataFrame.arrange(asc: col("full name"), desc: id)\
+               |> Explorer.DataFrame.arrange(asc: col("full name"), desc: id)
+               |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -621,7 +662,10 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, operations)
 
       assert DataTransformCell.to_source(attrs) == """
-             teams |> Explorer.DataFrame.group_by("weekdays")\
+             teams
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.collect()
+             |> Explorer.DataFrame.group_by("weekdays")\
              """
     end
 
@@ -641,7 +685,10 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, operations)
 
       assert DataTransformCell.to_source(attrs) == """
-             teams |> Explorer.DataFrame.group_by(["hour", "day"])\
+             teams
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.collect()
+             |> Explorer.DataFrame.group_by(["hour", "day"])\
              """
     end
 
@@ -670,6 +717,8 @@ defmodule KinoExplorer.DataTransformCellTest do
 
       assert DataTransformCell.to_source(attrs) == """
              teams
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.collect()
              |> Explorer.DataFrame.group_by("weekdays")
              |> Explorer.DataFrame.summarise(hour_max: max(hour))\
              """
@@ -700,6 +749,8 @@ defmodule KinoExplorer.DataTransformCellTest do
 
       assert DataTransformCell.to_source(attrs) == """
              teams
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.collect()
              |> Explorer.DataFrame.group_by("weekdays")
              |> Explorer.DataFrame.summarise(hour_max: max(hour), day_max: max(day))\
              """
@@ -736,6 +787,8 @@ defmodule KinoExplorer.DataTransformCellTest do
 
       assert DataTransformCell.to_source(attrs) == """
              teams
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.collect()
              |> Explorer.DataFrame.group_by("weekdays")
              |> Explorer.DataFrame.summarise(
                hour_max: max(hour),
@@ -762,7 +815,10 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, operations)
 
       assert DataTransformCell.to_source(attrs) == """
-             teams |> Explorer.DataFrame.pivot_wider("weekdays", "hour")\
+             teams
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.collect()
+             |> Explorer.DataFrame.pivot_wider("weekdays", "hour")\
              """
     end
 
@@ -783,7 +839,10 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, operations)
 
       assert DataTransformCell.to_source(attrs) == """
-             teams |> Explorer.DataFrame.pivot_wider("weekdays", ["hour", "day"])\
+             teams
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.collect()
+             |> Explorer.DataFrame.pivot_wider("weekdays", ["hour", "day"])\
              """
     end
 
@@ -803,7 +862,10 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, operations)
 
       assert DataTransformCell.to_source(attrs) == """
-             teams |> Explorer.DataFrame.discard("weekdays")\
+             teams
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.discard("weekdays")
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -823,7 +885,10 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, operations)
 
       assert DataTransformCell.to_source(attrs) == """
-             teams |> Explorer.DataFrame.discard(["hour", "day"])\
+             teams
+             |> Explorer.DataFrame.to_lazy()
+             |> Explorer.DataFrame.discard(["hour", "day"])
+             |> Explorer.DataFrame.collect()\
              """
     end
 
@@ -854,7 +919,7 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, operations)
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> DF.filter(name == "Ana" and id < 2)\
+             people |> DF.to_lazy() |> DF.filter(name == "Ana" and id < 2) |> DF.collect()\
              """
     end
 
@@ -885,7 +950,7 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, operations)
 
       assert DataTransformCell.to_source(attrs) == """
-             people |> DF.new() |> DF.filter(name == "Ana" and id < 2)\
+             people |> DF.new(lazy: true) |> DF.filter(name == "Ana" and id < 2) |> DF.collect()\
              """
     end
 
@@ -924,7 +989,8 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, operations)
 
       assert DataTransformCell.to_source(attrs) == """
-             exported_df = people |> DF.filter(name == "Ana" and id < 2)\
+             exported_df =
+               people |> DF.to_lazy() |> DF.filter(name == "Ana" and id < 2) |> DF.collect()\
              """
     end
 
@@ -977,7 +1043,12 @@ defmodule KinoExplorer.DataTransformCellTest do
       attrs = build_attrs(root, operations)
 
       assert DataTransformCell.to_source(attrs) == """
-             exported_df = people |> DF.filter(name == "Ana") |> DF.arrange(asc: col("full name"))\
+             exported_df =
+               people
+               |> DF.to_lazy()
+               |> DF.filter(name == "Ana")
+               |> DF.arrange(asc: col("full name"))
+               |> DF.collect()\
              """
     end
 
@@ -988,8 +1059,7 @@ defmodule KinoExplorer.DataTransformCellTest do
         "data_frame_alias" => DF,
         "missing_require" => nil,
         "is_data_frame" => true,
-        "lazy" => false,
-        "collect" => false
+        "collect" => true
       }
 
       operations = [
@@ -1030,9 +1100,11 @@ defmodule KinoExplorer.DataTransformCellTest do
       assert DataTransformCell.to_source(attrs) == """
              exported_df =
                people
+               |> DF.to_lazy()
                |> DF.filter(name == "Ana" and id < 2)
                |> DF.arrange(asc: col("full name"))
-               |> DF.filter(contains(surname, "Santiago"))\
+               |> DF.filter(contains(surname, "Santiago"))
+               |> DF.collect()\
              """
     end
 
@@ -1068,13 +1140,13 @@ defmodule KinoExplorer.DataTransformCellTest do
 
       assert DataTransformCell.to_source(attrs) == """
              require Explorer.DataFrame
-             exported_df = people |> DF.filter(name == "Ana" and id < 2)\
+
+             exported_df =
+               people |> DF.to_lazy() |> DF.filter(name == "Ana" and id < 2) |> DF.collect()\
              """
     end
 
     test "source for a lazy data frame with collect" do
-      root = %{"lazy" => true, "collect" => true}
-
       operations = %{
         sorting: [
           %{
@@ -1096,7 +1168,7 @@ defmodule KinoExplorer.DataTransformCellTest do
         ]
       }
 
-      attrs = build_attrs(root, operations)
+      attrs = build_attrs(operations)
 
       assert DataTransformCell.to_source(attrs) == """
              people
@@ -1108,7 +1180,7 @@ defmodule KinoExplorer.DataTransformCellTest do
     end
 
     test "source for a lazy data frame without collect" do
-      root = %{"lazy" => true}
+      root = %{"collect" => false}
 
       operations = %{
         sorting: [
@@ -1145,7 +1217,6 @@ defmodule KinoExplorer.DataTransformCellTest do
       root = %{
         "data_frame" => "simple_data",
         "is_data_frame" => false,
-        "lazy" => true,
         "collect" => true
       }
 
@@ -1182,7 +1253,7 @@ defmodule KinoExplorer.DataTransformCellTest do
     end
 
     test "source for a lazy data without collect" do
-      root = %{"data_frame" => "simple_data", "is_data_frame" => false, "lazy" => true}
+      root = %{"data_frame" => "simple_data", "is_data_frame" => false}
 
       operations = %{
         sorting: [
@@ -1211,13 +1282,13 @@ defmodule KinoExplorer.DataTransformCellTest do
              simple_data
              |> Explorer.DataFrame.new(lazy: true)
              |> Explorer.DataFrame.filter(col("full name") == "Ana")
-             |> Explorer.DataFrame.arrange(asc: col("full name"))\
+             |> Explorer.DataFrame.arrange(asc: col("full name"))
+             |> Explorer.DataFrame.collect()\
              """
     end
 
     test "source for a lazy data frame without operations" do
-      root = %{"lazy" => true}
-      attrs = build_attrs(root, %{})
+      attrs = build_attrs(%{}, %{})
 
       assert DataTransformCell.to_source(attrs) == """
              people\
@@ -1225,16 +1296,16 @@ defmodule KinoExplorer.DataTransformCellTest do
     end
 
     test "source for a lazy data without operations" do
-      root = %{"data_frame" => "simple_data", "is_data_frame" => false, "lazy" => true}
+      root = %{"data_frame" => "simple_data", "is_data_frame" => false}
       attrs = build_attrs(root, %{})
 
       assert DataTransformCell.to_source(attrs) == """
-             simple_data |> Explorer.DataFrame.new(lazy: true)\
+             simple_data |> Explorer.DataFrame.new(lazy: true) |> Explorer.DataFrame.collect()\
              """
     end
 
-    test "auto collect before a pivot_wider" do
-      root = %{"data_frame" => "teams", "lazy" => true, "data_frame_alias" => DF}
+    test "auto collect before a group_by" do
+      root = %{"data_frame" => "teams", "data_frame_alias" => DF}
 
       operations = %{
         group_by: [
@@ -1259,8 +1330,8 @@ defmodule KinoExplorer.DataTransformCellTest do
       assert DataTransformCell.to_source(attrs) == """
              teams
              |> DF.to_lazy()
-             |> DF.group_by("weekdays")
              |> DF.collect()
+             |> DF.group_by("weekdays")
              |> DF.pivot_wider("weekdays", "hour")\
              """
     end

--- a/test/kino_explorer/data_transform_cell_test.exs
+++ b/test/kino_explorer/data_transform_cell_test.exs
@@ -1323,6 +1323,82 @@ defmodule KinoExplorer.DataTransformCellTest do
              """
     end
 
+    test "collect only after the first group" do
+      attrs = %{
+        "assign_to" => nil,
+        "collect" => true,
+        "data_frame" => "fuels",
+        "data_frame_alias" => DF,
+        "is_data_frame" => true,
+        "missing_require" => nil,
+        "operations" => [
+          %{
+            "active" => true,
+            "columns" => ["cement", "country", "bunker_fuels"],
+            "operation_type" => "group_by"
+          },
+          %{
+            "active" => true,
+            "direction" => "asc",
+            "operation_type" => "sorting",
+            "sort_by" => "bunker_fuels"
+          },
+          %{
+            "active" => true,
+            "columns" => ["cement"],
+            "operation_type" => "group_by"
+          }
+        ]
+      }
+
+      assert DataTransformCell.to_source(attrs) == """
+             fuels
+             |> DF.to_lazy()
+             |> DF.group_by(["cement", "country", "bunker_fuels"])
+             |> DF.collect()
+             |> DF.arrange(asc: bunker_fuels)
+             |> DF.group_by("cement")\
+             """
+    end
+
+    test "auto collect only after the first group" do
+      attrs = %{
+        "assign_to" => nil,
+        "collect" => false,
+        "data_frame" => "fuels",
+        "data_frame_alias" => DF,
+        "is_data_frame" => true,
+        "missing_require" => nil,
+        "operations" => [
+          %{
+            "active" => true,
+            "columns" => ["cement", "country", "bunker_fuels"],
+            "operation_type" => "group_by"
+          },
+          %{
+            "active" => true,
+            "direction" => "asc",
+            "operation_type" => "sorting",
+            "sort_by" => "bunker_fuels"
+          },
+          %{
+            "active" => true,
+            "columns" => ["cement"],
+            "operation_type" => "group_by"
+          }
+        ]
+      }
+
+      assert DataTransformCell.to_source(attrs) == """
+             fuels
+             |> DF.to_lazy()
+             |> DF.group_by(["cement", "country", "bunker_fuels"])
+             |> DF.collect()
+             |> DF.arrange(asc: bunker_fuels)
+             |> DF.group_by("cement")\
+             """
+    end
+
     test "does not generate noop lazy and collect when a pivot_wider is the only operation" do
       root = %{"data_frame" => "teams", "data_frame_alias" => DF}
 


### PR DESCRIPTION
- Lazy by default without collect
- Auto collect when there's a `pivot_wider`
- For non data frames: `DF.new(data, lazy: true)`
- Doesn't generate noop

<img width="924" alt="Screenshot 2023-06-06 at 21 56 31" src="https://github.com/livebook-dev/kino_explorer/assets/5660941/a45bcd67-08fe-4b5c-b3be-d8651cd00480">
