### PR TITLE
Add support for `not` in `contains` operations

### DIFF
--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -22,16 +22,16 @@ defmodule KinoExplorer.DataTransformCell do
     "time"
   ]
   @filter_options %{
-    "binary" => ["equal", "contains", "not equal"],
+    "binary" => ["equal", "contains", "not contains", "not equal"],
     "boolean" => ["equal", "not equal"],
-    "category" => ["equal", "contains", "not equal"],
+    "category" => ["equal", "contains", "not contains", "not equal"],
     "date" => ["less", "less equal", "equal", "not equal", "greater equal", "greater"],
     "datetime[ms]" => ["less", "less equal", "equal", "not equal", "greater equal", "greater"],
     "datetime[μs]" => ["less", "less equal", "equal", "not equal", "greater equal", "greater"],
     "datetime[ns]" => ["less", "less equal", "equal", "not equal", "greater equal", "greater"],
     "float" => ["less", "less equal", "equal", "not equal", "greater equal", "greater"],
     "integer" => ["less", "less equal", "equal", "not equal", "greater equal", "greater"],
-    "string" => ["equal", "contains", "not equal"],
+    "string" => ["equal", "contains", "not contains", "not equal"],
     "time" => ["less", "less equal", "equal", "not equal", "greater equal", "greater"]
   }
   @fill_missing_options %{
@@ -96,7 +96,8 @@ defmodule KinoExplorer.DataTransformCell do
     "not equal" => "!=",
     "greater equal" => ">=",
     "greater" => ">",
-    "contains" => "contains"
+    "contains" => "contains",
+    "not contains" => "not contains"
   }
 
   @multiselect_operations [:discard, :group_by]

--- a/test/kino_explorer/data_transform_cell_test.exs
+++ b/test/kino_explorer/data_transform_cell_test.exs
@@ -1180,6 +1180,35 @@ defmodule KinoExplorer.DataTransformCellTest do
              """
     end
 
+    test "not contains" do
+      root = %{
+        "data_frame" => "people",
+        "assign_to" => "exported_df",
+        "data_frame_alias" => DF,
+        "missing_require" => nil,
+        "is_data_frame" => true,
+        "collect" => true
+      }
+
+      operations = [
+        %{
+          "column" => "surname",
+          "filter" => "not contains",
+          "type" => "string",
+          "value" => "Santiago",
+          "active" => true,
+          "operation_type" => "filters"
+        }
+      ]
+
+      attrs = Map.put(root, "operations", operations)
+
+      assert DataTransformCell.to_source(attrs) == """
+             exported_df =
+               people |> DF.lazy() |> DF.filter(not contains(surname, "Santiago")) |> DF.collect()\
+             """
+    end
+
     test "source with an auto generated require" do
       root = %{
         "data_frame_alias" => DF,


### PR DESCRIPTION
I was doing some stuff with explorer today and noticed there's no option for `not contains`.

It looks like a straightforward change, so I had a go at adding it.

I'm not 100% sure it makes sense for the `binary` and `category` types, but  it seems to match their usages.

Happy to make changes if I've made some incorrect assumptions

Have tested it on a local livebook and seems to work