### PR TITLE
Allow string typed filters for lists

### DIFF
--- a/lib/kino_explorer/data_transform_cell.ex
+++ b/lib/kino_explorer/data_transform_cell.ex
@@ -795,8 +795,8 @@ defmodule KinoExplorer.DataTransformCell do
           cast_typed_value("float", value)
         end
 
-      _ ->
-        nil
+      :error ->
+        {:ok, value}
     end
   end
 

--- a/test/kino_explorer/data_transform_cell_test.exs
+++ b/test/kino_explorer/data_transform_cell_test.exs
@@ -560,37 +560,6 @@ defmodule KinoExplorer.DataTransformCellTest do
               "value" => "5",
               "active" => true,
               "operation_type" => "filters"
-            }
-          ]
-        })
-
-      assert DataTransformCell.to_source(attrs) == """
-             people
-             |> Explorer.DataFrame.lazy()
-             |> Explorer.DataFrame.filter(member?(list_column, 3) and not member?(list_column, 5))
-             |> Explorer.DataFrame.collect()\
-             """
-    end
-
-    test "do not generate code for invalid filter for lists" do
-      attrs =
-        build_attrs(%{
-          filters: [
-            %{
-              "column" => "list_column",
-              "filter" => "contains",
-              "type" => "list",
-              "value" => "3",
-              "active" => true,
-              "operation_type" => "filters"
-            },
-            %{
-              "column" => "list_column",
-              "filter" => "not contains",
-              "type" => "list",
-              "value" => "5",
-              "active" => true,
-              "operation_type" => "filters"
             },
             %{
               "column" => "list_column",
@@ -606,7 +575,10 @@ defmodule KinoExplorer.DataTransformCellTest do
       assert DataTransformCell.to_source(attrs) == """
              people
              |> Explorer.DataFrame.lazy()
-             |> Explorer.DataFrame.filter(member?(list_column, 3) and not member?(list_column, 5))
+             |> Explorer.DataFrame.filter(
+               member?(list_column, 3) and not member?(list_column, 5) and
+                 not member?(list_column, "cat")
+             )
              |> Explorer.DataFrame.collect()\
              """
     end


### PR DESCRIPTION
I had a situation where I needed to filter on a list of string -- currently only integer and floats are supported. Here's the related discussion I had on Slack for more context:

![Screenshot 2025-01-31 at 2 41 21 PM](https://github.com/user-attachments/assets/e4d978b2-6f57-4263-9a00-1b9cc8517c30)

Here's an example using this branch:

![Screenshot 2025-02-28 at 3 22 48 PM](https://github.com/user-attachments/assets/a2b05983-36f6-4792-a5b2-1a4947655e6c)
