### PR TITLE
use `DataFrame.groups` to get the groups

### DIFF
--- a/lib/kino/explorer.ex
+++ b/lib/kino/explorer.ex
@@ -289,7 +289,7 @@ defmodule Kino.Explorer do
 
   defp prepare_data(df, summaries) do
     lazy = lazy?(df)
-    groups = df.groups
+    groups = DataFrame.groups(df)
     df = DataFrame.ungroup(df)
     total_rows = if !lazy, do: DataFrame.n_rows(df)
     columns = columns(df, lazy, groups, summaries)


### PR DESCRIPTION
This fixes a small bug from after the structure of a `DataFrame` `:groups` was updated in `0.11.1`.

This updates the logic to use the `Explorer.DataFrame.groups/1` function.